### PR TITLE
Fix 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.2.2.tgz",
       "integrity": "sha512-YKgNbG2dlzqMhA9NtI3/pbY16m3Yl/EeWBRa+lB1X1YaYxHrxNexiQYCLTWO/uDvAjLFMEDU+zR901waBtMtjQ==",
       "requires": {
-        "tinycolor2": "1.4.1"
+        "tinycolor2": "^1.4.1"
       }
     },
     "@ant-design/icons": {
@@ -22,8 +22,8 @@
       "resolved": "https://registry.npmjs.org/@ant-design/icons-vue/-/icons-vue-2.0.0.tgz",
       "integrity": "sha512-2c0QQE5hL4N48k5NkPG5sdpMl9YnvyNhf0U7YkdZYDlLnspoRU7vIA0UK9eHBs6OpFLcJB6o8eJrIl2ajBskPg==",
       "requires": {
-        "@ant-design/colors": "3.2.2",
-        "babel-runtime": "6.26.0"
+        "@ant-design/colors": "^3.1.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "@apollo/federation": {
@@ -32,10 +32,10 @@
       "integrity": "sha512-+UA9QQNA4q896OOmyFHhKTf7iOIFvjL+h/I7ozRkA+Ayv1368pXtd3zyeKrXtUKD21a1vtEkEjCUX9aDGR8cqg==",
       "dev": true,
       "requires": {
-        "apollo-graphql": "0.4.4",
-        "apollo-server-env": "2.4.4",
-        "core-js": "3.6.5",
-        "lodash.xorby": "4.7.0"
+        "apollo-graphql": "^0.4.0",
+        "apollo-server-env": "^2.4.4-alpha.0",
+        "core-js": "^3.4.0",
+        "lodash.xorby": "^4.7.0"
       }
     },
     "@apollo/protobufjs": {
@@ -44,19 +44,19 @@
       "integrity": "sha512-EE3zx+/D/wur/JiLp6VCiw1iYdyy1lCJMf8CGPkLeDt5QJrN4N8tKFx33Ah4V30AUQzMk7Uz4IXKZ1LOj124gA==",
       "dev": true,
       "requires": {
-        "@protobufjs/aspromise": "1.1.2",
-        "@protobufjs/base64": "1.1.2",
-        "@protobufjs/codegen": "2.0.4",
-        "@protobufjs/eventemitter": "1.1.0",
-        "@protobufjs/fetch": "1.1.0",
-        "@protobufjs/float": "1.0.2",
-        "@protobufjs/inquire": "1.1.0",
-        "@protobufjs/path": "1.1.2",
-        "@protobufjs/pool": "1.1.0",
-        "@protobufjs/utf8": "1.1.0",
-        "@types/long": "4.0.1",
-        "@types/node": "10.17.24",
-        "long": "4.0.0"
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
       },
       "dependencies": {
         "@types/node": {
@@ -73,7 +73,7 @@
       "integrity": "sha512-W2+HB8Y7ifowcf3YyPHgDI05izyRtOeZ4MqIr7LbTArtmJ0ZHULWpn84SGMW7NAvTV1tFExpHlveHhnXuJfuGA==",
       "dev": true,
       "requires": {
-        "apollo-env": "0.6.5"
+        "apollo-env": "^0.6.5"
       }
     },
     "@apollographql/graphql-language-service-interface": {
@@ -82,9 +82,9 @@
       "integrity": "sha512-28wePK0hlIVjgmvMXMAUq8qRSjz9O+6lqFp4PzOTHtfJfSsjVe9EfjF98zTpHsTgT3HcOxmbqDZZy8jlXtOqEA==",
       "dev": true,
       "requires": {
-        "@apollographql/graphql-language-service-parser": "2.0.2",
-        "@apollographql/graphql-language-service-types": "2.0.2",
-        "@apollographql/graphql-language-service-utils": "2.0.2"
+        "@apollographql/graphql-language-service-parser": "^2.0.0",
+        "@apollographql/graphql-language-service-types": "^2.0.0",
+        "@apollographql/graphql-language-service-utils": "^2.0.2"
       }
     },
     "@apollographql/graphql-language-service-parser": {
@@ -93,7 +93,7 @@
       "integrity": "sha512-rpTPrEJu1PMaRQxz5P8BZWsixNNhYloS0H0dwTxNBuE3qctbARvR7o8UCKLsmKgTbo+cz3T3a6IAsWlkHgMWGg==",
       "dev": true,
       "requires": {
-        "@apollographql/graphql-language-service-types": "2.0.2"
+        "@apollographql/graphql-language-service-types": "^2.0.0"
       }
     },
     "@apollographql/graphql-language-service-types": {
@@ -108,7 +108,7 @@
       "integrity": "sha512-fDj5rWlTi/czvUS5t7V7I45Ai6bOO3Z7JARYj21Y2xxfbRGtJi6h8FvLX0N/EbzQgo/fiZc/HAhtfwn+OCjD7A==",
       "dev": true,
       "requires": {
-        "@apollographql/graphql-language-service-types": "2.0.2"
+        "@apollographql/graphql-language-service-types": "^2.0.0"
       }
     },
     "@apollographql/graphql-playground-html": {
@@ -123,7 +123,7 @@
       "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.10.1"
+        "@babel/highlight": "^7.10.1"
       }
     },
     "@babel/compat-data": {
@@ -132,9 +132,9 @@
       "integrity": "sha512-CHvCj7So7iCkGKPRFUfryXIkU2gSBw7VSZFYLsqVhrS47269VK2Hfi9S/YcublPMW8k1u2bQBlbDruoQEm4fgw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.12.0",
-        "invariant": "2.2.4",
-        "semver": "5.7.1"
+        "browserslist": "^4.12.0",
+        "invariant": "^2.2.4",
+        "semver": "^5.5.0"
       }
     },
     "@babel/core": {
@@ -143,22 +143,22 @@
       "integrity": "sha512-u8XiZ6sMXW/gPmoP5ijonSUln4unazG291X0XAQ5h0s8qnAFr6BRRZGUEK+jtRWdmB0NTJQt7Uga25q8GetIIg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.10.1",
-        "@babel/generator": "7.10.1",
-        "@babel/helper-module-transforms": "7.10.1",
-        "@babel/helpers": "7.10.1",
-        "@babel/parser": "7.10.1",
-        "@babel/template": "7.10.1",
-        "@babel/traverse": "7.10.1",
-        "@babel/types": "7.10.1",
-        "convert-source-map": "1.7.0",
-        "debug": "4.1.1",
-        "gensync": "1.0.0-beta.1",
-        "json5": "2.1.3",
-        "lodash": "4.17.15",
-        "resolve": "1.17.0",
-        "semver": "5.7.1",
-        "source-map": "0.5.7"
+        "@babel/code-frame": "^7.10.1",
+        "@babel/generator": "^7.10.1",
+        "@babel/helper-module-transforms": "^7.10.1",
+        "@babel/helpers": "^7.10.1",
+        "@babel/parser": "^7.10.1",
+        "@babel/template": "^7.10.1",
+        "@babel/traverse": "^7.10.1",
+        "@babel/types": "^7.10.1",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
       }
     },
     "@babel/generator": {
@@ -167,10 +167,10 @@
       "integrity": "sha512-AT0YPLQw9DI21tliuJIdplVfLHya6mcGa8ctkv7n4Qv+hYacJrKmNWIteAK1P9iyLikFIAkwqJ7HAOqIDLFfgA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.10.1",
-        "jsesc": "2.5.2",
-        "lodash": "4.17.15",
-        "source-map": "0.5.7"
+        "@babel/types": "^7.10.1",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -179,7 +179,7 @@
       "integrity": "sha512-ewp3rvJEwLaHgyWGe4wQssC2vjks3E80WiUe2BpMb0KhreTjMROCbxXcEovTrbeGVdQct5VjQfrv9EgC+xMzCw==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.10.1"
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -188,8 +188,8 @@
       "integrity": "sha512-cQpVq48EkYxUU0xozpGCLla3wlkdRRqLWu1ksFMXA9CM5KQmyyRpSEsYXbao7JUkOw/tAaYKCaYyZq6HOFYtyw==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.10.1",
-        "@babel/types": "7.10.1"
+        "@babel/helper-explode-assignable-expression": "^7.10.1",
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-compilation-targets": {
@@ -198,11 +198,11 @@
       "integrity": "sha512-YuF8IrgSmX/+MV2plPkjEnzlC2wf+gaok8ehMNN0jodF3/sejZauExqpEVGbJua62oaWoNYIXwz4RmAsVcGyHw==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "7.10.1",
-        "browserslist": "4.12.0",
-        "invariant": "2.2.4",
-        "levenary": "1.1.1",
-        "semver": "5.7.1"
+        "@babel/compat-data": "^7.10.1",
+        "browserslist": "^4.12.0",
+        "invariant": "^2.2.4",
+        "levenary": "^1.1.1",
+        "semver": "^5.5.0"
       }
     },
     "@babel/helper-create-class-features-plugin": {
@@ -211,12 +211,12 @@
       "integrity": "sha512-bwhdehBJZt84HuPUcP1HaTLuc/EywVS8rc3FgsEPDcivg+DCW+SHuLHVkYOmcBA1ZfI+Z/oZjQc/+bPmIO7uAA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.10.1",
-        "@babel/helper-member-expression-to-functions": "7.10.1",
-        "@babel/helper-optimise-call-expression": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/helper-replace-supers": "7.10.1",
-        "@babel/helper-split-export-declaration": "7.10.1"
+        "@babel/helper-function-name": "^7.10.1",
+        "@babel/helper-member-expression-to-functions": "^7.10.1",
+        "@babel/helper-optimise-call-expression": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-replace-supers": "^7.10.1",
+        "@babel/helper-split-export-declaration": "^7.10.1"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
@@ -225,9 +225,9 @@
       "integrity": "sha512-Rx4rHS0pVuJn5pJOqaqcZR4XSgeF9G/pO/79t+4r7380tXFJdzImFnxMU19f83wjSrmKHq6myrM10pFHTGzkUA==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.10.1",
-        "@babel/helper-regex": "7.10.1",
-        "regexpu-core": "4.7.0"
+        "@babel/helper-annotate-as-pure": "^7.10.1",
+        "@babel/helper-regex": "^7.10.1",
+        "regexpu-core": "^4.7.0"
       }
     },
     "@babel/helper-define-map": {
@@ -236,9 +236,9 @@
       "integrity": "sha512-+5odWpX+OnvkD0Zmq7panrMuAGQBu6aPUgvMzuMGo4R+jUOvealEj2hiqI6WhxgKrTpFoFj0+VdsuA8KDxHBDg==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.10.1",
-        "@babel/types": "7.10.1",
-        "lodash": "4.17.15"
+        "@babel/helper-function-name": "^7.10.1",
+        "@babel/types": "^7.10.1",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -247,8 +247,8 @@
       "integrity": "sha512-vcUJ3cDjLjvkKzt6rHrl767FeE7pMEYfPanq5L16GRtrXIoznc0HykNW2aEYkcnP76P0isoqJ34dDMFZwzEpJg==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.10.1",
-        "@babel/types": "7.10.1"
+        "@babel/traverse": "^7.10.1",
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-function-name": {
@@ -257,9 +257,9 @@
       "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.10.1",
-        "@babel/template": "7.10.1",
-        "@babel/types": "7.10.1"
+        "@babel/helper-get-function-arity": "^7.10.1",
+        "@babel/template": "^7.10.1",
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -268,7 +268,7 @@
       "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.10.1"
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -277,7 +277,7 @@
       "integrity": "sha512-vLm5srkU8rI6X3+aQ1rQJyfjvCBLXP8cAGeuw04zeAM2ItKb1e7pmVmLyHb4sDaAYnLL13RHOZPLEtcGZ5xvjg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.10.1"
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -286,7 +286,7 @@
       "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.10.1"
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-module-imports": {
@@ -295,7 +295,7 @@
       "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.10.1"
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-module-transforms": {
@@ -304,13 +304,13 @@
       "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.10.1",
-        "@babel/helper-replace-supers": "7.10.1",
-        "@babel/helper-simple-access": "7.10.1",
-        "@babel/helper-split-export-declaration": "7.10.1",
-        "@babel/template": "7.10.1",
-        "@babel/types": "7.10.1",
-        "lodash": "4.17.15"
+        "@babel/helper-module-imports": "^7.10.1",
+        "@babel/helper-replace-supers": "^7.10.1",
+        "@babel/helper-simple-access": "^7.10.1",
+        "@babel/helper-split-export-declaration": "^7.10.1",
+        "@babel/template": "^7.10.1",
+        "@babel/types": "^7.10.1",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -319,7 +319,7 @@
       "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.10.1"
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -334,7 +334,7 @@
       "integrity": "sha512-7isHr19RsIJWWLLFn21ubFt223PjQyg1HY7CZEMRr820HttHPpVvrsIN3bUOo44DEfFV4kBXO7Abbn9KTUZV7g==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.15"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -343,11 +343,11 @@
       "integrity": "sha512-RfX1P8HqsfgmJ6CwaXGKMAqbYdlleqglvVtht0HGPMSsy2V6MqLlOJVF/0Qyb/m2ZCi2z3q3+s6Pv7R/dQuZ6A==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.10.1",
-        "@babel/helper-wrap-function": "7.10.1",
-        "@babel/template": "7.10.1",
-        "@babel/traverse": "7.10.1",
-        "@babel/types": "7.10.1"
+        "@babel/helper-annotate-as-pure": "^7.10.1",
+        "@babel/helper-wrap-function": "^7.10.1",
+        "@babel/template": "^7.10.1",
+        "@babel/traverse": "^7.10.1",
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-replace-supers": {
@@ -356,10 +356,10 @@
       "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "7.10.1",
-        "@babel/helper-optimise-call-expression": "7.10.1",
-        "@babel/traverse": "7.10.1",
-        "@babel/types": "7.10.1"
+        "@babel/helper-member-expression-to-functions": "^7.10.1",
+        "@babel/helper-optimise-call-expression": "^7.10.1",
+        "@babel/traverse": "^7.10.1",
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-simple-access": {
@@ -368,8 +368,8 @@
       "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.10.1",
-        "@babel/types": "7.10.1"
+        "@babel/template": "^7.10.1",
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -378,7 +378,7 @@
       "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.10.1"
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -393,10 +393,10 @@
       "integrity": "sha512-C0MzRGteVDn+H32/ZgbAv5r56f2o1fZSA/rj/TYo8JEJNHg+9BdSmKBUND0shxWRztWhjlT2cvHYuynpPsVJwQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.10.1",
-        "@babel/template": "7.10.1",
-        "@babel/traverse": "7.10.1",
-        "@babel/types": "7.10.1"
+        "@babel/helper-function-name": "^7.10.1",
+        "@babel/template": "^7.10.1",
+        "@babel/traverse": "^7.10.1",
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helpers": {
@@ -405,9 +405,9 @@
       "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.10.1",
-        "@babel/traverse": "7.10.1",
-        "@babel/types": "7.10.1"
+        "@babel/template": "^7.10.1",
+        "@babel/traverse": "^7.10.1",
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/highlight": {
@@ -416,9 +416,9 @@
       "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "7.10.1",
-        "chalk": "2.4.2",
-        "js-tokens": "4.0.0"
+        "@babel/helper-validator-identifier": "^7.10.1",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
@@ -433,9 +433,9 @@
       "integrity": "sha512-vzZE12ZTdB336POZjmpblWfNNRpMSua45EYnRigE2XsZxcXcIyly2ixnTJasJE4Zq3U7t2d8rRF7XRUuzHxbOw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/helper-remap-async-to-generator": "7.10.1",
-        "@babel/plugin-syntax-async-generators": "7.8.4"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-remap-async-to-generator": "^7.10.1",
+        "@babel/plugin-syntax-async-generators": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-class-properties": {
@@ -444,8 +444,8 @@
       "integrity": "sha512-sqdGWgoXlnOdgMXU+9MbhzwFRgxVLeiGBqTrnuS7LC2IBU31wSsESbTUreT2O418obpfPdGUR2GbEufZF1bpqw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-create-class-features-plugin": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-proposal-decorators": {
@@ -454,9 +454,9 @@
       "integrity": "sha512-xBfteh352MTke2U1NpclzMDmAmCdQ2fBZjhZQQfGTjXw6qcRYMkt528sA1U8o0ThDCSeuETXIj5bOGdxN+5gkw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/plugin-syntax-decorators": "7.10.1"
+        "@babel/helper-create-class-features-plugin": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/plugin-syntax-decorators": "^7.10.1"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
@@ -465,8 +465,8 @@
       "integrity": "sha512-Cpc2yUVHTEGPlmiQzXj026kqwjEQAD9I4ZC16uzdbgWgitg/UHKHLffKNCQZ5+y8jpIZPJcKcwsr2HwPh+w3XA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/plugin-syntax-dynamic-import": "7.8.3"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -475,8 +475,8 @@
       "integrity": "sha512-m8r5BmV+ZLpWPtMY2mOKN7wre6HIO4gfIiV+eOmsnZABNenrt/kzYBwrh+KOfgumSWpnlGs5F70J8afYMSJMBg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/plugin-syntax-json-strings": "7.8.3"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/plugin-syntax-json-strings": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
@@ -485,8 +485,8 @@
       "integrity": "sha512-56cI/uHYgL2C8HVuHOuvVowihhX0sxb3nnfVRzUeVHTWmRHTZrKuAh/OBIMggGU/S1g/1D2CRCXqP+3u7vX7iA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "7.8.3"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-numeric-separator": {
@@ -495,8 +495,8 @@
       "integrity": "sha512-jjfym4N9HtCiNfyyLAVD8WqPYeHUrw4ihxuAynWj6zzp2gf9Ey2f7ImhFm6ikB3CLf5Z/zmcJDri6B4+9j9RsA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/plugin-syntax-numeric-separator": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.1"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
@@ -505,9 +505,9 @@
       "integrity": "sha512-Z+Qri55KiQkHh7Fc4BW6o+QBuTagbOp9txE+4U1i79u9oWlf2npkiDx+Rf3iK3lbcHBuNy9UOkwuR5wOMH3LIQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@babel/plugin-transform-parameters": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-transform-parameters": "^7.10.1"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -516,8 +516,8 @@
       "integrity": "sha512-VqExgeE62YBqI3ogkGoOJp1R6u12DFZjqwJhqtKc2o5m1YTUuUWnos7bZQFBhwkxIFpWYJ7uB75U7VAPPiKETA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/plugin-syntax-optional-catch-binding": "7.8.3"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
@@ -526,8 +526,8 @@
       "integrity": "sha512-dqQj475q8+/avvok72CF3AOSV/SGEcH29zT5hhohqqvvZ2+boQoOr7iGldBG5YXTO2qgCgc2B3WvVLUdbeMlGA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/plugin-syntax-optional-chaining": "7.8.3"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-private-methods": {
@@ -536,8 +536,8 @@
       "integrity": "sha512-RZecFFJjDiQ2z6maFprLgrdnm0OzoC23Mx89xf1CcEsxmHuzuXOdniEuI+S3v7vjQG4F5sa6YtUp+19sZuSxHg==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-create-class-features-plugin": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -546,8 +546,8 @@
       "integrity": "sha512-JjfngYRvwmPwmnbRZyNiPFI8zxCZb8euzbCG/LxyKdeTb59tVciKo9GK9bi6JYKInk1H11Dq9j/zRqIH4KigfQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -556,7 +556,7 @@
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-class-properties": {
@@ -565,7 +565,7 @@
       "integrity": "sha512-Gf2Yx/iRs1JREDtVZ56OrjjgFHCaldpTnuy9BHla10qyVT3YkIIGEtoDWhyop0ksu1GvNjHIoYRBqm3zoR1jyQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-syntax-decorators": {
@@ -574,7 +574,7 @@
       "integrity": "sha512-a9OAbQhKOwSle1Vr0NJu/ISg1sPfdEkfRKWpgPuzhnWWzForou2gIeUIIwjAMHRekhhpJ7eulZlYs0H14Cbi+g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -583,7 +583,7 @@
       "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -592,7 +592,7 @@
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-jsx": {
@@ -601,7 +601,7 @@
       "integrity": "sha512-+OxyOArpVFXQeXKLO9o+r2I4dIoVoy6+Uu0vKELrlweDM3QJADZj+Z+5ERansZqIZBcLj42vHnDI8Rz9BnRIuQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -610,7 +610,7 @@
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-numeric-separator": {
@@ -619,7 +619,7 @@
       "integrity": "sha512-uTd0OsHrpe3tH5gRPTxG8Voh99/WCU78vIm5NMRYPAqC8lR4vajt6KkCAknCHrx24vkPdd/05yfdGSB4EIY2mg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -628,7 +628,7 @@
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
@@ -637,7 +637,7 @@
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-optional-chaining": {
@@ -646,7 +646,7 @@
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-top-level-await": {
@@ -655,7 +655,7 @@
       "integrity": "sha512-hgA5RYkmZm8FTFT3yu2N9Bx7yVVOKYT6yEdXXo6j2JTm0wNxgqaGeQVaSHRjhfnQbX91DtjFB6McRFSlcJH3xQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -664,7 +664,7 @@
       "integrity": "sha512-6AZHgFJKP3DJX0eCNJj01RpytUa3SOGawIxweHkNX2L6PYikOZmoh5B0d7hIHaIgveMjX990IAa/xK7jRTN8OA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -673,9 +673,9 @@
       "integrity": "sha512-XCgYjJ8TY2slj6SReBUyamJn3k2JLUIiiR5b6t1mNCMSvv7yx+jJpaewakikp0uWFQSF7ChPPoe3dHmXLpISkg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/helper-remap-async-to-generator": "7.10.1"
+        "@babel/helper-module-imports": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-remap-async-to-generator": "^7.10.1"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -684,7 +684,7 @@
       "integrity": "sha512-B7K15Xp8lv0sOJrdVAoukKlxP9N59HS48V1J3U/JGj+Ad+MHq+am6xJVs85AgXrQn4LV8vaYFOB+pr/yIuzW8Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -693,8 +693,8 @@
       "integrity": "sha512-8bpWG6TtF5akdhIm/uWTyjHqENpy13Fx8chg7pFH875aNLwX8JxIxqm08gmAT+Whe6AOmaTeLPe7dpLbXt+xUw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "lodash": "4.17.15"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -703,14 +703,14 @@
       "integrity": "sha512-P9V0YIh+ln/B3RStPoXpEQ/CoAxQIhRSUn7aXqQ+FZJ2u8+oCtjIXR3+X0vsSD8zv+mb56K7wZW1XiDTDGiDRQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.10.1",
-        "@babel/helper-define-map": "7.10.1",
-        "@babel/helper-function-name": "7.10.1",
-        "@babel/helper-optimise-call-expression": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/helper-replace-supers": "7.10.1",
-        "@babel/helper-split-export-declaration": "7.10.1",
-        "globals": "11.12.0"
+        "@babel/helper-annotate-as-pure": "^7.10.1",
+        "@babel/helper-define-map": "^7.10.1",
+        "@babel/helper-function-name": "^7.10.1",
+        "@babel/helper-optimise-call-expression": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-replace-supers": "^7.10.1",
+        "@babel/helper-split-export-declaration": "^7.10.1",
+        "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -719,7 +719,7 @@
       "integrity": "sha512-mqSrGjp3IefMsXIenBfGcPXxJxweQe2hEIwMQvjtiDQ9b1IBvDUjkAtV/HMXX47/vXf14qDNedXsIiNd1FmkaQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -728,7 +728,7 @@
       "integrity": "sha512-V/nUc4yGWG71OhaTH705pU8ZSdM6c1KmmLP8ys59oOYbT7RpMYAR3MsVOt6OHL0WzG7BlTU076va9fjJyYzJMA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -737,8 +737,8 @@
       "integrity": "sha512-19VIMsD1dp02RvduFUmfzj8uknaO3uiHHF0s3E1OHnVsNj8oge8EQ5RzHRbJjGSetRnkEuBYO7TG1M5kKjGLOA==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -747,7 +747,7 @@
       "integrity": "sha512-wIEpkX4QvX8Mo9W6XF3EdGttrIPZWozHfEaDTU0WJD/TDnXMvdDh30mzUl/9qWhnf7naicYartcEfUghTCSNpA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -756,8 +756,8 @@
       "integrity": "sha512-lr/przdAbpEA2BUzRvjXdEDLrArGRRPwbaF9rvayuHRvdQ7lUTTkZnhZrJ4LE2jvgMRFF4f0YuPQ20vhiPYxtA==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -766,7 +766,7 @@
       "integrity": "sha512-US8KCuxfQcn0LwSCMWMma8M2R5mAjJGsmoCBVwlMygvmDUMkTCykc84IqN1M7t+agSfOmLYTInLCHJM+RUoz+w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -775,8 +775,8 @@
       "integrity": "sha512-//bsKsKFBJfGd65qSNNh1exBy5Y9gD9ZN+DvrJ8f7HXr4avE5POW6zB7Rj6VnqHV33+0vXWUwJT0wSHubiAQkw==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-function-name": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-literals": {
@@ -785,7 +785,7 @@
       "integrity": "sha512-qi0+5qgevz1NHLZroObRm5A+8JJtibb7vdcPQF1KQE12+Y/xxl8coJ+TpPW9iRq+Mhw/NKLjm+5SHtAHCC7lAw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
@@ -794,7 +794,7 @@
       "integrity": "sha512-UmaWhDokOFT2GcgU6MkHC11i0NQcL63iqeufXWfRy6pUOGYeCGEKhvfFO6Vz70UfYJYHwveg62GS83Rvpxn+NA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-modules-amd": {
@@ -803,9 +803,9 @@
       "integrity": "sha512-31+hnWSFRI4/ACFr1qkboBbrTxoBIzj7qA69qlq8HY8p7+YCzkCT6/TvQ1a4B0z27VeWtAeJd6pr5G04dc1iHw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1",
-        "babel-plugin-dynamic-import-node": "2.3.3"
+        "@babel/helper-module-transforms": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
@@ -814,10 +814,10 @@
       "integrity": "sha512-AQG4fc3KOah0vdITwt7Gi6hD9BtQP/8bhem7OjbaMoRNCH5Djx42O2vYMfau7QnAzQCa+RJnhJBmFFMGpQEzrg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/helper-simple-access": "7.10.1",
-        "babel-plugin-dynamic-import-node": "2.3.3"
+        "@babel/helper-module-transforms": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-simple-access": "^7.10.1",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
@@ -826,10 +826,10 @@
       "integrity": "sha512-ewNKcj1TQZDL3YnO85qh9zo1YF1CHgmSTlRQgHqe63oTrMI85cthKtZjAiZSsSNjPQ5NCaYo5QkbYqEw1ZBgZA==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.10.1",
-        "@babel/helper-module-transforms": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1",
-        "babel-plugin-dynamic-import-node": "2.3.3"
+        "@babel/helper-hoist-variables": "^7.10.1",
+        "@babel/helper-module-transforms": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -838,8 +838,8 @@
       "integrity": "sha512-EIuiRNMd6GB6ulcYlETnYYfgv4AxqrswghmBRQbWLHZxN4s7mupxzglnHqk9ZiUpDI4eRWewedJJNj67PWOXKA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-module-transforms": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
@@ -848,7 +848,7 @@
       "integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "7.10.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -857,7 +857,7 @@
       "integrity": "sha512-MBlzPc1nJvbmO9rPr1fQwXOM2iGut+JC92ku6PbiJMMK7SnQc1rytgpopveE3Evn47gzvGYeCdgfCDbZo0ecUw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-object-super": {
@@ -866,8 +866,8 @@
       "integrity": "sha512-WnnStUDN5GL+wGQrJylrnnVlFhFmeArINIR9gjhSeYyvroGhBrSAXYg/RHsnfzmsa+onJrTJrEClPzgNmmQ4Gw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/helper-replace-supers": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-replace-supers": "^7.10.1"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -876,8 +876,8 @@
       "integrity": "sha512-tJ1T0n6g4dXMsL45YsSzzSDZCxiHXAQp/qHrucOq5gEHncTA3xDxnd5+sZcoQp+N1ZbieAaB8r/VUCG0gqseOg==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-get-function-arity": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-property-literals": {
@@ -886,7 +886,7 @@
       "integrity": "sha512-Kr6+mgag8auNrgEpbfIWzdXYOvqDHZOF0+Bx2xh4H2EDNwcbRb9lY6nkZg8oSjsX+DH9Ebxm9hOqtKW+gRDeNA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -895,7 +895,7 @@
       "integrity": "sha512-B3+Y2prScgJ2Bh/2l9LJxKbb8C8kRfsG4AdPT+n7ixBHIxJaIG8bi8tgjxUMege1+WqSJ+7gu1YeoMVO3gPWzw==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.14.4"
+        "regenerator-transform": "^0.14.2"
       }
     },
     "@babel/plugin-transform-reserved-words": {
@@ -904,7 +904,7 @@
       "integrity": "sha512-qN1OMoE2nuqSPmpTqEM7OvJ1FkMEV+BjVeZZm9V9mq/x1JLKQ4pcv8riZJMNN3u2AUGl0ouOMjRr2siecvHqUQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-runtime": {
@@ -913,10 +913,10 @@
       "integrity": "sha512-4w2tcglDVEwXJ5qxsY++DgWQdNJcCCsPxfT34wCUwIf2E7dI7pMpH8JczkMBbgBTNzBX62SZlNJ9H+De6Zebaw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1",
-        "resolve": "1.17.0",
-        "semver": "5.7.1"
+        "@babel/helper-module-imports": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -925,7 +925,7 @@
       "integrity": "sha512-AR0E/lZMfLstScFwztApGeyTHJ5u3JUKMjneqRItWeEqDdHWZwAOKycvQNCasCK/3r5YXsuNG25funcJDu7Y2g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-spread": {
@@ -934,7 +934,7 @@
       "integrity": "sha512-8wTPym6edIrClW8FI2IoaePB91ETOtg36dOkj3bYcNe7aDMN2FXEoUa+WrmPc4xa1u2PQK46fUX2aCb+zo9rfw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -943,8 +943,8 @@
       "integrity": "sha512-j17ojftKjrL7ufX8ajKvwRilwqTok4q+BjkknmQw9VNHnItTyMP5anPFzxFJdCQs7clLcWpCV3ma+6qZWLnGMA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/helper-regex": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-regex": "^7.10.1"
       }
     },
     "@babel/plugin-transform-template-literals": {
@@ -953,8 +953,8 @@
       "integrity": "sha512-t7B/3MQf5M1T9hPCRG28DNGZUuxAuDqLYS03rJrIk2prj/UV7Z6FOneijhQhnv/Xa039vidXeVbvjK2SK5f7Gg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-annotate-as-pure": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
@@ -963,7 +963,7 @@
       "integrity": "sha512-qX8KZcmbvA23zDi+lk9s6hC1FM7jgLHYIjuLgULgc8QtYnmB3tAVIYkNoKRQ75qWBeyzcoMoK8ZQmogGtC/w0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-unicode-escapes": {
@@ -972,7 +972,7 @@
       "integrity": "sha512-zZ0Poh/yy1d4jeDWpx/mNwbKJVwUYJX73q+gyh4bwtG0/iUlzdEu0sLMda8yuDFS6LBQlT/ST1SJAR6zYwXWgw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -981,8 +981,8 @@
       "integrity": "sha512-Y/2a2W299k0VIUdbqYm9X2qS6fE0CUBhhiPpimK6byy7OJ/kORLlIX+J6UrjgNu5awvs62k+6RSslxhcvVw2Tw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
     "@babel/preset-env": {
@@ -991,70 +991,70 @@
       "integrity": "sha512-bGWNfjfXRLnqbN2T4lB3pMfoic8dkRrmHpVZamSFHzGy5xklyHTobZ28TVUD2grhE5WDnu67tBj8oslIhkiOMQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "7.10.1",
-        "@babel/helper-compilation-targets": "7.10.1",
-        "@babel/helper-module-imports": "7.10.1",
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/plugin-proposal-async-generator-functions": "7.10.1",
-        "@babel/plugin-proposal-class-properties": "7.10.1",
-        "@babel/plugin-proposal-dynamic-import": "7.10.1",
-        "@babel/plugin-proposal-json-strings": "7.10.1",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "7.10.1",
-        "@babel/plugin-proposal-numeric-separator": "7.10.1",
-        "@babel/plugin-proposal-object-rest-spread": "7.10.1",
-        "@babel/plugin-proposal-optional-catch-binding": "7.10.1",
-        "@babel/plugin-proposal-optional-chaining": "7.10.1",
-        "@babel/plugin-proposal-private-methods": "7.10.1",
-        "@babel/plugin-proposal-unicode-property-regex": "7.10.1",
-        "@babel/plugin-syntax-async-generators": "7.8.4",
-        "@babel/plugin-syntax-class-properties": "7.10.1",
-        "@babel/plugin-syntax-dynamic-import": "7.8.3",
-        "@babel/plugin-syntax-json-strings": "7.8.3",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "7.10.1",
-        "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "7.8.3",
-        "@babel/plugin-syntax-top-level-await": "7.10.1",
-        "@babel/plugin-transform-arrow-functions": "7.10.1",
-        "@babel/plugin-transform-async-to-generator": "7.10.1",
-        "@babel/plugin-transform-block-scoped-functions": "7.10.1",
-        "@babel/plugin-transform-block-scoping": "7.10.1",
-        "@babel/plugin-transform-classes": "7.10.1",
-        "@babel/plugin-transform-computed-properties": "7.10.1",
-        "@babel/plugin-transform-destructuring": "7.10.1",
-        "@babel/plugin-transform-dotall-regex": "7.10.1",
-        "@babel/plugin-transform-duplicate-keys": "7.10.1",
-        "@babel/plugin-transform-exponentiation-operator": "7.10.1",
-        "@babel/plugin-transform-for-of": "7.10.1",
-        "@babel/plugin-transform-function-name": "7.10.1",
-        "@babel/plugin-transform-literals": "7.10.1",
-        "@babel/plugin-transform-member-expression-literals": "7.10.1",
-        "@babel/plugin-transform-modules-amd": "7.10.1",
-        "@babel/plugin-transform-modules-commonjs": "7.10.1",
-        "@babel/plugin-transform-modules-systemjs": "7.10.1",
-        "@babel/plugin-transform-modules-umd": "7.10.1",
-        "@babel/plugin-transform-named-capturing-groups-regex": "7.8.3",
-        "@babel/plugin-transform-new-target": "7.10.1",
-        "@babel/plugin-transform-object-super": "7.10.1",
-        "@babel/plugin-transform-parameters": "7.10.1",
-        "@babel/plugin-transform-property-literals": "7.10.1",
-        "@babel/plugin-transform-regenerator": "7.10.1",
-        "@babel/plugin-transform-reserved-words": "7.10.1",
-        "@babel/plugin-transform-shorthand-properties": "7.10.1",
-        "@babel/plugin-transform-spread": "7.10.1",
-        "@babel/plugin-transform-sticky-regex": "7.10.1",
-        "@babel/plugin-transform-template-literals": "7.10.1",
-        "@babel/plugin-transform-typeof-symbol": "7.10.1",
-        "@babel/plugin-transform-unicode-escapes": "7.10.1",
-        "@babel/plugin-transform-unicode-regex": "7.10.1",
-        "@babel/preset-modules": "0.1.3",
-        "@babel/types": "7.10.1",
-        "browserslist": "4.12.0",
-        "core-js-compat": "3.6.5",
-        "invariant": "2.2.4",
-        "levenary": "1.1.1",
-        "semver": "5.7.1"
+        "@babel/compat-data": "^7.10.1",
+        "@babel/helper-compilation-targets": "^7.10.1",
+        "@babel/helper-module-imports": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/plugin-proposal-async-generator-functions": "^7.10.1",
+        "@babel/plugin-proposal-class-properties": "^7.10.1",
+        "@babel/plugin-proposal-dynamic-import": "^7.10.1",
+        "@babel/plugin-proposal-json-strings": "^7.10.1",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
+        "@babel/plugin-proposal-numeric-separator": "^7.10.1",
+        "@babel/plugin-proposal-object-rest-spread": "^7.10.1",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.10.1",
+        "@babel/plugin-proposal-optional-chaining": "^7.10.1",
+        "@babel/plugin-proposal-private-methods": "^7.10.1",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.10.1",
+        "@babel/plugin-syntax-async-generators": "^7.8.0",
+        "@babel/plugin-syntax-class-properties": "^7.10.1",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.1",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+        "@babel/plugin-syntax-top-level-await": "^7.10.1",
+        "@babel/plugin-transform-arrow-functions": "^7.10.1",
+        "@babel/plugin-transform-async-to-generator": "^7.10.1",
+        "@babel/plugin-transform-block-scoped-functions": "^7.10.1",
+        "@babel/plugin-transform-block-scoping": "^7.10.1",
+        "@babel/plugin-transform-classes": "^7.10.1",
+        "@babel/plugin-transform-computed-properties": "^7.10.1",
+        "@babel/plugin-transform-destructuring": "^7.10.1",
+        "@babel/plugin-transform-dotall-regex": "^7.10.1",
+        "@babel/plugin-transform-duplicate-keys": "^7.10.1",
+        "@babel/plugin-transform-exponentiation-operator": "^7.10.1",
+        "@babel/plugin-transform-for-of": "^7.10.1",
+        "@babel/plugin-transform-function-name": "^7.10.1",
+        "@babel/plugin-transform-literals": "^7.10.1",
+        "@babel/plugin-transform-member-expression-literals": "^7.10.1",
+        "@babel/plugin-transform-modules-amd": "^7.10.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.10.1",
+        "@babel/plugin-transform-modules-systemjs": "^7.10.1",
+        "@babel/plugin-transform-modules-umd": "^7.10.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+        "@babel/plugin-transform-new-target": "^7.10.1",
+        "@babel/plugin-transform-object-super": "^7.10.1",
+        "@babel/plugin-transform-parameters": "^7.10.1",
+        "@babel/plugin-transform-property-literals": "^7.10.1",
+        "@babel/plugin-transform-regenerator": "^7.10.1",
+        "@babel/plugin-transform-reserved-words": "^7.10.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.10.1",
+        "@babel/plugin-transform-spread": "^7.10.1",
+        "@babel/plugin-transform-sticky-regex": "^7.10.1",
+        "@babel/plugin-transform-template-literals": "^7.10.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.10.1",
+        "@babel/plugin-transform-unicode-escapes": "^7.10.1",
+        "@babel/plugin-transform-unicode-regex": "^7.10.1",
+        "@babel/preset-modules": "^0.1.3",
+        "@babel/types": "^7.10.1",
+        "browserslist": "^4.12.0",
+        "core-js-compat": "^3.6.2",
+        "invariant": "^2.2.2",
+        "levenary": "^1.1.1",
+        "semver": "^5.5.0"
       }
     },
     "@babel/preset-modules": {
@@ -1063,11 +1063,11 @@
       "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.10.1",
-        "@babel/plugin-proposal-unicode-property-regex": "7.10.1",
-        "@babel/plugin-transform-dotall-regex": "7.10.1",
-        "@babel/types": "7.10.1",
-        "esutils": "2.0.3"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
       }
     },
     "@babel/runtime": {
@@ -1076,7 +1076,7 @@
       "integrity": "sha512-nQbbCbQc9u/rpg1XCxoMYQTbSMVZjCDxErQ1ClCn9Pvcmv1lGads19ep0a2VsEiIJeHqjZley6EQGEC3Yo1xMA==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "0.13.5"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
@@ -1085,9 +1085,9 @@
       "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.10.1",
-        "@babel/parser": "7.10.1",
-        "@babel/types": "7.10.1"
+        "@babel/code-frame": "^7.10.1",
+        "@babel/parser": "^7.10.1",
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/traverse": {
@@ -1096,15 +1096,15 @@
       "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.10.1",
-        "@babel/generator": "7.10.1",
-        "@babel/helper-function-name": "7.10.1",
-        "@babel/helper-split-export-declaration": "7.10.1",
-        "@babel/parser": "7.10.1",
-        "@babel/types": "7.10.1",
-        "debug": "4.1.1",
-        "globals": "11.12.0",
-        "lodash": "4.17.15"
+        "@babel/code-frame": "^7.10.1",
+        "@babel/generator": "^7.10.1",
+        "@babel/helper-function-name": "^7.10.1",
+        "@babel/helper-split-export-declaration": "^7.10.1",
+        "@babel/parser": "^7.10.1",
+        "@babel/types": "^7.10.1",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/types": {
@@ -1113,9 +1113,9 @@
       "integrity": "sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "7.10.1",
-        "lodash": "4.17.15",
-        "to-fast-properties": "2.0.0"
+        "@babel/helper-validator-identifier": "^7.10.1",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@endemolshinegroup/cosmiconfig-typescript-loader": {
@@ -1124,10 +1124,10 @@
       "integrity": "sha512-bhUR9035PbgL6A/nfLayjoqKo4W7hCtzxqVxq2cgDB+Ndpsa3dGIr71/ymgY3vCTCQaufkFxAcEeoECyJ498CA==",
       "dev": true,
       "requires": {
-        "lodash.get": "4.4.2",
-        "make-error": "1.3.6",
-        "ts-node": "8.10.2",
-        "tslib": "1.13.0"
+        "lodash.get": "^4",
+        "make-error": "^1",
+        "ts-node": "^8",
+        "tslib": "^1"
       }
     },
     "@fullcalendar/core": {
@@ -1155,7 +1155,7 @@
       "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-4.4.2.tgz",
       "integrity": "sha512-M5an7qii8OUmI4ogY47k5pn2j/qUbLp6sa6Vo0gO182HR5pb9YtrEZnoQhnScok+I0BkDkLFzMQoiAMTjBm2PQ==",
       "requires": {
-        "@fullcalendar/daygrid": "4.4.2"
+        "@fullcalendar/daygrid": "~4.4.0"
       }
     },
     "@fullcalendar/vue": {
@@ -1163,8 +1163,8 @@
       "resolved": "https://registry.npmjs.org/@fullcalendar/vue/-/vue-4.4.2.tgz",
       "integrity": "sha512-Iq5l8s0exyUI2vicPDs1Hn6SFLy0gnFAOEINqXixmnn9+U2fHgM++ofal1yKqpU9bAWE4d58Mizu2tlDlc6NyQ==",
       "requires": {
-        "@fullcalendar/core": "4.4.2",
-        "fast-deep-equal": "2.0.1"
+        "@fullcalendar/core": "~4.4.0",
+        "fast-deep-equal": "^2.0.1"
       },
       "dependencies": {
         "fast-deep-equal": {
@@ -1198,10 +1198,10 @@
       "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
       "dev": true,
       "requires": {
-        "@hapi/address": "2.1.4",
-        "@hapi/bourne": "1.3.2",
-        "@hapi/hoek": "8.5.1",
-        "@hapi/topo": "3.1.6"
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
       }
     },
     "@hapi/topo": {
@@ -1210,7 +1210,7 @@
       "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "8.5.1"
+        "@hapi/hoek": "^8.3.0"
       }
     },
     "@intervolga/optimize-cssnano-plugin": {
@@ -1219,9 +1219,9 @@
       "integrity": "sha512-zN69TnSr0viRSU6cEDIcuPcP67QcpQ6uHACg58FiN9PDrU6SLyGW3MR4tiISbYxy1kDWAVPwD+XwQTWE5cigAA==",
       "dev": true,
       "requires": {
-        "cssnano": "4.1.10",
-        "cssnano-preset-default": "4.0.7",
-        "postcss": "7.0.31"
+        "cssnano": "^4.0.0",
+        "cssnano-preset-default": "^4.0.0",
+        "postcss": "^7.0.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1230,8 +1230,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "glob-to-regexp": "0.3.0"
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -1245,9 +1245,9 @@
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.3.0.tgz",
       "integrity": "sha512-Vf09BxCdj1iT2IRqVwX5snaY2WCTkvM0O4cWWSO1ThCFuc4if0Q/nNwAgCxRU0FeYHJ7DdyMUNSdswCLKlVqeg==",
       "requires": {
-        "chalk": "2.4.2",
-        "consola": "2.12.2",
-        "node-fetch": "2.6.0"
+        "chalk": "^2.4.2",
+        "consola": "^2.10.1",
+        "node-fetch": "^2.6.0"
       }
     },
     "@oclif/color": {
@@ -1256,11 +1256,11 @@
       "integrity": "sha512-M9o+DOrb8l603qvgz1FogJBUGLqcMFL1aFg2ZEL0FbXJofiNTLOWIeB4faeZTLwE6dt0xH9GpCVpzksMMzGbmA==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "chalk": "3.0.0",
-        "strip-ansi": "5.2.0",
-        "supports-color": "5.5.0",
-        "tslib": "1.13.0"
+        "ansi-styles": "^3.2.1",
+        "chalk": "^3.0.0",
+        "strip-ansi": "^5.2.0",
+        "supports-color": "^5.4.0",
+        "tslib": "^1"
       },
       "dependencies": {
         "chalk": {
@@ -1269,8 +1269,8 @@
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
-            "ansi-styles": "4.2.1",
-            "supports-color": "7.1.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -1279,8 +1279,8 @@
               "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "dev": true,
               "requires": {
-                "@types/color-name": "1.1.1",
-                "color-convert": "2.0.1"
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
               }
             },
             "supports-color": {
@@ -1289,7 +1289,7 @@
               "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
               "dev": true,
               "requires": {
-                "has-flag": "4.0.0"
+                "has-flag": "^4.0.0"
               }
             }
           }
@@ -1300,7 +1300,7 @@
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.4"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
@@ -1321,7 +1321,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -1332,12 +1332,12 @@
       "integrity": "sha512-pvmMmfGn+zm4e4RwVw63mg9sIaqKqmVsFbImQoUrCO/43UmWzoSHWNXKdgEGigOezWrkZfFucaeZcSbp149OWg==",
       "dev": true,
       "requires": {
-        "@oclif/config": "1.15.1",
-        "@oclif/errors": "1.2.2",
-        "@oclif/parser": "3.8.5",
-        "@oclif/plugin-help": "3.1.0",
-        "debug": "4.1.1",
-        "semver": "5.7.1"
+        "@oclif/config": "^1.15.1",
+        "@oclif/errors": "^1.2.2",
+        "@oclif/parser": "^3.8.3",
+        "@oclif/plugin-help": "^3",
+        "debug": "^4.1.1",
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "@oclif/plugin-help": {
@@ -1346,15 +1346,15 @@
           "integrity": "sha512-orSWpXGlJaX16eSjAtI8scA8QhrjQOaCSHodEx52t18JKbIVzG8jcngugyWAOB/V4jhPl0rdiVk9XFsaIIiG2g==",
           "dev": true,
           "requires": {
-            "@oclif/command": "1.6.1",
-            "@oclif/config": "1.15.1",
-            "chalk": "2.4.2",
-            "indent-string": "4.0.0",
-            "lodash.template": "4.5.0",
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0",
-            "widest-line": "2.0.1",
-            "wrap-ansi": "4.0.0"
+            "@oclif/command": "^1.5.20",
+            "@oclif/config": "^1.15.1",
+            "chalk": "^2.4.1",
+            "indent-string": "^4.0.0",
+            "lodash.template": "^4.4.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0",
+            "widest-line": "^2.0.1",
+            "wrap-ansi": "^4.0.0"
           }
         },
         "emoji-regex": {
@@ -1375,9 +1375,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -1386,7 +1386,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "wrap-ansi": {
@@ -1395,9 +1395,9 @@
           "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -1412,8 +1412,8 @@
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
               }
             },
             "strip-ansi": {
@@ -1422,7 +1422,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -1435,10 +1435,10 @@
       "integrity": "sha512-GdyHpEZuWlfU8GSaZoiywtfVBsPcfYn1KuSLT1JTfvZGpPG6vShcGr24YZ3HG2jXUFlIuAqDcYlTzOrqOdTPNQ==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "1.2.2",
-        "@oclif/parser": "3.8.5",
-        "debug": "4.1.1",
-        "tslib": "1.13.0"
+        "@oclif/errors": "^1.0.0",
+        "@oclif/parser": "^3.8.0",
+        "debug": "^4.1.1",
+        "tslib": "^1.9.3"
       }
     },
     "@oclif/errors": {
@@ -1447,11 +1447,11 @@
       "integrity": "sha512-Eq8BFuJUQcbAPVofDxwdE0bL14inIiwt5EaKRVY9ZDIG11jwdXZqiQEECJx0VfnLyUZdYfRd/znDI/MytdJoKg==",
       "dev": true,
       "requires": {
-        "clean-stack": "1.3.0",
-        "fs-extra": "7.0.1",
-        "indent-string": "3.2.0",
-        "strip-ansi": "5.2.0",
-        "wrap-ansi": "4.0.0"
+        "clean-stack": "^1.3.0",
+        "fs-extra": "^7.0.0",
+        "indent-string": "^3.2.0",
+        "strip-ansi": "^5.0.0",
+        "wrap-ansi": "^4.0.0"
       },
       "dependencies": {
         "clean-stack": {
@@ -1478,8 +1478,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -1494,7 +1494,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -1505,7 +1505,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "wrap-ansi": {
@@ -1514,9 +1514,9 @@
           "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -1531,7 +1531,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -1550,10 +1550,10 @@
       "integrity": "sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==",
       "dev": true,
       "requires": {
-        "@oclif/errors": "1.2.2",
-        "@oclif/linewrap": "1.0.0",
-        "chalk": "2.4.2",
-        "tslib": "1.13.0"
+        "@oclif/errors": "^1.2.2",
+        "@oclif/linewrap": "^1.0.0",
+        "chalk": "^2.4.2",
+        "tslib": "^1.9.3"
       }
     },
     "@oclif/plugin-autocomplete": {
@@ -1562,13 +1562,13 @@
       "integrity": "sha512-pHbaE2PH7d9lHjCgFrrQ+ZIwvY+7OAQaGoaANqDbicBNDK/Rszt4N4oGj22dJT7sCQ8a/3Eh942rjxYIq9Mi9Q==",
       "dev": true,
       "requires": {
-        "@oclif/command": "1.6.1",
-        "@oclif/config": "1.15.1",
-        "chalk": "2.4.2",
-        "cli-ux": "5.4.6",
-        "debug": "4.1.1",
-        "fs-extra": "7.0.1",
-        "moment": "2.26.0"
+        "@oclif/command": "^1.5.13",
+        "@oclif/config": "^1.13.0",
+        "chalk": "^2.4.1",
+        "cli-ux": "^5.2.1",
+        "debug": "^4.0.0",
+        "fs-extra": "^7.0.0",
+        "moment": "^2.22.1"
       }
     },
     "@oclif/plugin-help": {
@@ -1577,14 +1577,14 @@
       "integrity": "sha512-bGHUdo5e7DjPJ0vTeRBMIrfqTRDBfyR5w0MP41u0n3r7YG5p14lvMmiCXxi6WDaP2Hw5nqx3PnkAIntCKZZN7g==",
       "dev": true,
       "requires": {
-        "@oclif/command": "1.6.1",
-        "chalk": "2.4.2",
-        "indent-string": "4.0.0",
-        "lodash.template": "4.5.0",
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0",
-        "widest-line": "2.0.1",
-        "wrap-ansi": "4.0.0"
+        "@oclif/command": "^1.5.13",
+        "chalk": "^2.4.1",
+        "indent-string": "^4.0.0",
+        "lodash.template": "^4.4.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0",
+        "widest-line": "^2.0.1",
+        "wrap-ansi": "^4.0.0"
       },
       "dependencies": {
         "emoji-regex": {
@@ -1605,9 +1605,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -1616,7 +1616,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "wrap-ansi": {
@@ -1625,9 +1625,9 @@
           "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -1642,8 +1642,8 @@
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
               }
             },
             "strip-ansi": {
@@ -1652,7 +1652,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -1665,11 +1665,11 @@
       "integrity": "sha512-G440PCuMi/OT8b71aWkR+kCWikngGtyRjOR24sPMDbpUFV4+B3r51fz1fcqeUiiEOYqUpr0Uy/sneUe1O/NfBg==",
       "dev": true,
       "requires": {
-        "@oclif/color": "0.1.2",
-        "@oclif/command": "1.6.1",
-        "cli-ux": "4.9.3",
-        "fast-levenshtein": "2.0.6",
-        "lodash": "4.17.15"
+        "@oclif/color": "^0.x",
+        "@oclif/command": "^1.6.0",
+        "cli-ux": "^4.9.0",
+        "fast-levenshtein": "^2.0.6",
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -1684,27 +1684,27 @@
           "integrity": "sha512-/1owvF0SZ5Gn54cgrikJ0QskgTzeg30HGjkmjFoaHDJzAqFpuX1DBpFR8aLvsE1J5s9MgeYRENQK4BFwOag5VA==",
           "dev": true,
           "requires": {
-            "@oclif/errors": "1.2.2",
-            "@oclif/linewrap": "1.0.0",
-            "@oclif/screen": "1.0.4",
-            "ansi-escapes": "3.2.0",
-            "ansi-styles": "3.2.1",
-            "cardinal": "2.1.1",
-            "chalk": "2.4.2",
-            "clean-stack": "2.2.0",
-            "extract-stack": "1.0.0",
-            "fs-extra": "7.0.1",
-            "hyperlinker": "1.0.0",
-            "indent-string": "3.2.0",
-            "is-wsl": "1.1.0",
-            "lodash": "4.17.15",
-            "password-prompt": "1.1.2",
-            "semver": "5.7.1",
-            "strip-ansi": "5.2.0",
-            "supports-color": "5.5.0",
-            "supports-hyperlinks": "1.0.1",
-            "treeify": "1.1.0",
-            "tslib": "1.13.0"
+            "@oclif/errors": "^1.2.2",
+            "@oclif/linewrap": "^1.0.0",
+            "@oclif/screen": "^1.0.3",
+            "ansi-escapes": "^3.1.0",
+            "ansi-styles": "^3.2.1",
+            "cardinal": "^2.1.1",
+            "chalk": "^2.4.1",
+            "clean-stack": "^2.0.0",
+            "extract-stack": "^1.0.0",
+            "fs-extra": "^7.0.0",
+            "hyperlinker": "^1.0.0",
+            "indent-string": "^3.2.0",
+            "is-wsl": "^1.1.0",
+            "lodash": "^4.17.11",
+            "password-prompt": "^1.0.7",
+            "semver": "^5.6.0",
+            "strip-ansi": "^5.0.0",
+            "supports-color": "^5.5.0",
+            "supports-hyperlinks": "^1.0.1",
+            "treeify": "^1.1.0",
+            "tslib": "^1.9.3"
           }
         },
         "indent-string": {
@@ -1719,7 +1719,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -1730,18 +1730,18 @@
       "integrity": "sha512-o7qfmiUGl+NUyA2lM18/Ch5sasGGYPIINR3cZ/AjwtdQ3ooINnF00pUDcUOtbjW97gRmk6/j79tcyTo8i7rHZg==",
       "dev": true,
       "requires": {
-        "@oclif/color": "0.0.0",
-        "@oclif/command": "1.6.1",
-        "chalk": "2.4.2",
-        "cli-ux": "5.4.6",
-        "debug": "4.1.1",
-        "fs-extra": "7.0.1",
-        "http-call": "5.3.0",
-        "load-json-file": "5.3.0",
-        "npm-run-path": "3.1.0",
-        "semver": "5.7.1",
-        "tslib": "1.13.0",
-        "yarn": "1.22.4"
+        "@oclif/color": "^0.0.0",
+        "@oclif/command": "^1.5.12",
+        "chalk": "^2.4.2",
+        "cli-ux": "^5.2.1",
+        "debug": "^4.1.0",
+        "fs-extra": "^7.0.1",
+        "http-call": "^5.2.2",
+        "load-json-file": "^5.2.0",
+        "npm-run-path": "^3.0.0",
+        "semver": "^5.6.0",
+        "tslib": "^1.9.3",
+        "yarn": "^1.21.1"
       },
       "dependencies": {
         "@oclif/color": {
@@ -1750,9 +1750,9 @@
           "integrity": "sha512-KKd3W7eNwfNF061tr663oUNdt8EMnfuyf5Xv55SGWA1a0rjhWqS/32P7OeB7CbXcJUBdfVrPyR//1afaW12AWw==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "supports-color": "5.5.0",
-            "tslib": "1.13.0"
+            "ansi-styles": "^3.2.1",
+            "supports-color": "^5.4.0",
+            "tslib": "^1"
           }
         },
         "npm-run-path": {
@@ -1761,7 +1761,7 @@
           "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.1"
+            "path-key": "^3.0.0"
           }
         },
         "path-key": {
@@ -1778,15 +1778,15 @@
       "integrity": "sha512-Nwyz3BJ8RhsfQ+OmFSsJSPIfn5YJqMrCzPh72Zgo2jqIjKIBWD8N9vTTe4kZlpeUUn77SyXFfwlBQbNCL5OEuQ==",
       "dev": true,
       "requires": {
-        "@oclif/command": "1.6.1",
-        "@oclif/config": "1.15.1",
-        "@oclif/errors": "1.2.2",
-        "chalk": "2.4.2",
-        "debug": "4.1.1",
-        "fs-extra": "7.0.1",
-        "http-call": "5.3.0",
-        "lodash.template": "4.5.0",
-        "semver": "5.7.1"
+        "@oclif/command": "^1.5.10",
+        "@oclif/config": "^1.12.8",
+        "@oclif/errors": "^1.2.2",
+        "chalk": "^2.4.1",
+        "debug": "^4.1.0",
+        "fs-extra": "^7.0.0",
+        "http-call": "^5.2.2",
+        "lodash.template": "^4.4.0",
+        "semver": "^5.6.0"
       }
     },
     "@oclif/screen": {
@@ -1825,8 +1825,8 @@
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "dev": true,
       "requires": {
-        "@protobufjs/aspromise": "1.1.2",
-        "@protobufjs/inquire": "1.1.0"
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
       }
     },
     "@protobufjs/float": {
@@ -1865,7 +1865,7 @@
       "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
       "dev": true,
       "requires": {
-        "any-observable": "0.3.0"
+        "any-observable": "^0.3.0"
       }
     },
     "@soda/friendly-errors-webpack-plugin": {
@@ -1874,9 +1874,9 @@
       "integrity": "sha512-cWKrGaFX+rfbMrAxVv56DzhPNqOJPZuNIS2HGMELtgGzb+vsMzyig9mml5gZ/hr2BGtSLV+dP2LUEuAL8aG2mQ==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "error-stack-parser": "2.0.6",
-        "string-width": "2.1.1"
+        "chalk": "^1.1.3",
+        "error-stack-parser": "^2.0.0",
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1897,11 +1897,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -1916,8 +1916,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -1932,7 +1932,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -1943,7 +1943,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -1966,7 +1966,7 @@
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "dev": true,
       "requires": {
-        "@types/node": "14.0.5"
+        "@types/node": "*"
       }
     },
     "@types/body-parser": {
@@ -1975,8 +1975,8 @@
       "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
       "dev": true,
       "requires": {
-        "@types/connect": "3.4.33",
-        "@types/node": "14.0.5"
+        "@types/connect": "*",
+        "@types/node": "*"
       }
     },
     "@types/color-name": {
@@ -1991,7 +1991,7 @@
       "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
       "dev": true,
       "requires": {
-        "@types/node": "14.0.5"
+        "@types/node": "*"
       }
     },
     "@types/content-disposition": {
@@ -2006,10 +2006,10 @@
       "integrity": "sha512-oTGtMzZZAVuEjTwCjIh8T8FrC8n/uwy+PG0yTvQcdZ7etoel7C7/3MSd7qrukENTgQtotG7gvBlBojuVs7X5rw==",
       "dev": true,
       "requires": {
-        "@types/connect": "3.4.33",
-        "@types/express": "4.17.4",
-        "@types/keygrip": "1.0.2",
-        "@types/node": "14.0.5"
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
       }
     },
     "@types/cors": {
@@ -2018,7 +2018,7 @@
       "integrity": "sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==",
       "dev": true,
       "requires": {
-        "@types/express": "4.17.4"
+        "@types/express": "*"
       }
     },
     "@types/events": {
@@ -2033,10 +2033,10 @@
       "integrity": "sha512-DO1L53rGqIDUEvOjJKmbMEQ5Z+BM2cIEPy/eV3En+s166Gz+FeuzRerxcab757u/U4v4XF4RYrZPmqKa+aY/2w==",
       "dev": true,
       "requires": {
-        "@types/body-parser": "1.19.0",
-        "@types/express-serve-static-core": "4.17.7",
-        "@types/qs": "6.9.3",
-        "@types/serve-static": "1.13.4"
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
@@ -2045,9 +2045,9 @@
       "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
       "dev": true,
       "requires": {
-        "@types/node": "14.0.5",
-        "@types/qs": "6.9.3",
-        "@types/range-parser": "1.2.3"
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
       }
     },
     "@types/fs-capacitor": {
@@ -2056,7 +2056,7 @@
       "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
       "dev": true,
       "requires": {
-        "@types/node": "14.0.5"
+        "@types/node": "*"
       }
     },
     "@types/glob": {
@@ -2065,9 +2065,9 @@
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
       "dev": true,
       "requires": {
-        "@types/events": "3.0.0",
-        "@types/minimatch": "3.0.3",
-        "@types/node": "14.0.5"
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
       }
     },
     "@types/graphql-upload": {
@@ -2076,10 +2076,10 @@
       "integrity": "sha512-hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==",
       "dev": true,
       "requires": {
-        "@types/express": "4.17.4",
-        "@types/fs-capacitor": "2.0.0",
-        "@types/koa": "2.11.3",
-        "graphql": "14.6.0"
+        "@types/express": "*",
+        "@types/fs-capacitor": "*",
+        "@types/koa": "*",
+        "graphql": "^14.5.3"
       },
       "dependencies": {
         "graphql": {
@@ -2088,7 +2088,7 @@
           "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
           "dev": true,
           "requires": {
-            "iterall": "1.3.0"
+            "iterall": "^1.2.2"
           }
         }
       }
@@ -2117,13 +2117,13 @@
       "integrity": "sha512-ABxVkrNWa4O/Jp24EYI/hRNqEVRlhB9g09p48neQp4m3xL1TJtdWk2NyNQSMCU45ejeELMQZBYyfstyVvO2H3Q==",
       "dev": true,
       "requires": {
-        "@types/accepts": "1.3.5",
-        "@types/content-disposition": "0.5.3",
-        "@types/cookies": "0.7.4",
-        "@types/http-assert": "1.5.1",
-        "@types/keygrip": "1.0.2",
-        "@types/koa-compose": "3.2.5",
-        "@types/node": "14.0.5"
+        "@types/accepts": "*",
+        "@types/content-disposition": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
       }
     },
     "@types/koa-compose": {
@@ -2132,7 +2132,7 @@
       "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
       "dev": true,
       "requires": {
-        "@types/koa": "2.11.3"
+        "@types/koa": "*"
       }
     },
     "@types/long": {
@@ -2164,8 +2164,8 @@
       "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
       "dev": true,
       "requires": {
-        "@types/node": "14.0.5",
-        "form-data": "3.0.0"
+        "@types/node": "*",
+        "form-data": "^3.0.0"
       },
       "dependencies": {
         "form-data": {
@@ -2174,9 +2174,9 @@
           "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.8",
-            "mime-types": "2.1.27"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
           }
         }
       }
@@ -2211,8 +2211,8 @@
       "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.17.7",
-        "@types/mime": "2.0.2"
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "@types/ws": {
@@ -2221,7 +2221,7 @@
       "integrity": "sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==",
       "dev": true,
       "requires": {
-        "@types/node": "14.0.5"
+        "@types/node": "*"
       }
     },
     "@types/zen-observable": {
@@ -2241,12 +2241,12 @@
       "integrity": "sha512-YfdaoSMvD1nj7+DsrwfTvTnhDXI7bsuh+Y5qWwvQXlD24uLgnsoww3qbiZvWf/EoviZMrvqkqN4CBw0W3BWUTQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.10.1",
-        "@babel/plugin-syntax-jsx": "7.10.1",
-        "@vue/babel-helper-vue-jsx-merge-props": "1.0.0",
-        "html-tags": "2.0.0",
-        "lodash.kebabcase": "4.1.1",
-        "svg-tags": "1.0.0"
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0",
+        "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
+        "html-tags": "^2.0.0",
+        "lodash.kebabcase": "^4.1.1",
+        "svg-tags": "^1.0.0"
       }
     },
     "@vue/babel-preset-app": {
@@ -2255,21 +2255,21 @@
       "integrity": "sha512-VHVROEBBiW0dnuNuzlFElkncXo+zxh5Px0MZ51Th5da8UPbQodf43mnpotMnFtmCPTXAFL58tzDttu1FgrgfpQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.10.1",
-        "@babel/helper-compilation-targets": "7.10.1",
-        "@babel/helper-module-imports": "7.10.1",
-        "@babel/plugin-proposal-class-properties": "7.10.1",
-        "@babel/plugin-proposal-decorators": "7.10.1",
-        "@babel/plugin-syntax-dynamic-import": "7.8.3",
-        "@babel/plugin-syntax-jsx": "7.10.1",
-        "@babel/plugin-transform-runtime": "7.10.1",
-        "@babel/preset-env": "7.10.1",
-        "@babel/runtime": "7.10.1",
-        "@vue/babel-preset-jsx": "1.1.2",
-        "babel-plugin-dynamic-import-node": "2.3.3",
-        "core-js": "3.6.5",
-        "core-js-compat": "3.6.5",
-        "semver": "6.3.0"
+        "@babel/core": "^7.9.6",
+        "@babel/helper-compilation-targets": "^7.9.6",
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/plugin-proposal-class-properties": "^7.8.3",
+        "@babel/plugin-proposal-decorators": "^7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-jsx": "^7.8.3",
+        "@babel/plugin-transform-runtime": "^7.9.6",
+        "@babel/preset-env": "^7.9.6",
+        "@babel/runtime": "^7.9.6",
+        "@vue/babel-preset-jsx": "^1.1.2",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "core-js": "^3.6.5",
+        "core-js-compat": "^3.6.5",
+        "semver": "^6.1.0"
       },
       "dependencies": {
         "semver": {
@@ -2286,12 +2286,12 @@
       "integrity": "sha512-zDpVnFpeC9YXmvGIDSsKNdL7qCG2rA3gjywLYHPCKDT10erjxF4U+6ay9X6TW5fl4GsDlJp9bVfAVQAAVzxxvQ==",
       "dev": true,
       "requires": {
-        "@vue/babel-helper-vue-jsx-merge-props": "1.0.0",
-        "@vue/babel-plugin-transform-vue-jsx": "1.1.2",
-        "@vue/babel-sugar-functional-vue": "1.1.2",
-        "@vue/babel-sugar-inject-h": "1.1.2",
-        "@vue/babel-sugar-v-model": "1.1.2",
-        "@vue/babel-sugar-v-on": "1.1.2"
+        "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
+        "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
+        "@vue/babel-sugar-functional-vue": "^1.1.2",
+        "@vue/babel-sugar-inject-h": "^1.1.2",
+        "@vue/babel-sugar-v-model": "^1.1.2",
+        "@vue/babel-sugar-v-on": "^1.1.2"
       }
     },
     "@vue/babel-sugar-functional-vue": {
@@ -2300,7 +2300,7 @@
       "integrity": "sha512-YhmdJQSVEFF5ETJXzrMpj0nkCXEa39TvVxJTuVjzvP2rgKhdMmQzlJuMv/HpadhZaRVMCCF3AEjjJcK5q/cYzQ==",
       "dev": true,
       "requires": {
-        "@babel/plugin-syntax-jsx": "7.10.1"
+        "@babel/plugin-syntax-jsx": "^7.2.0"
       }
     },
     "@vue/babel-sugar-inject-h": {
@@ -2309,7 +2309,7 @@
       "integrity": "sha512-VRSENdTvD5htpnVp7i7DNuChR5rVMcORdXjvv5HVvpdKHzDZAYiLSD+GhnhxLm3/dMuk8pSzV+k28ECkiN5m8w==",
       "dev": true,
       "requires": {
-        "@babel/plugin-syntax-jsx": "7.10.1"
+        "@babel/plugin-syntax-jsx": "^7.2.0"
       }
     },
     "@vue/babel-sugar-v-model": {
@@ -2318,12 +2318,12 @@
       "integrity": "sha512-vLXPvNq8vDtt0u9LqFdpGM9W9IWDmCmCyJXuozlq4F4UYVleXJ2Fa+3JsnTZNJcG+pLjjfnEGHci2339Kj5sGg==",
       "dev": true,
       "requires": {
-        "@babel/plugin-syntax-jsx": "7.10.1",
-        "@vue/babel-helper-vue-jsx-merge-props": "1.0.0",
-        "@vue/babel-plugin-transform-vue-jsx": "1.1.2",
-        "camelcase": "5.3.1",
-        "html-tags": "2.0.0",
-        "svg-tags": "1.0.0"
+        "@babel/plugin-syntax-jsx": "^7.2.0",
+        "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
+        "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
+        "camelcase": "^5.0.0",
+        "html-tags": "^2.0.0",
+        "svg-tags": "^1.0.0"
       }
     },
     "@vue/babel-sugar-v-on": {
@@ -2332,9 +2332,9 @@
       "integrity": "sha512-T8ZCwC8Jp2uRtcZ88YwZtZXe7eQrJcfRq0uTFy6ShbwYJyz5qWskRFoVsdTi9o0WEhmQXxhQUewodOSCUPVmsQ==",
       "dev": true,
       "requires": {
-        "@babel/plugin-syntax-jsx": "7.10.1",
-        "@vue/babel-plugin-transform-vue-jsx": "1.1.2",
-        "camelcase": "5.3.1"
+        "@babel/plugin-syntax-jsx": "^7.2.0",
+        "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
+        "camelcase": "^5.0.0"
       }
     },
     "@vue/cli-overlay": {
@@ -2349,13 +2349,13 @@
       "integrity": "sha512-dmhymfm2UnZDw13k/zKT6YIj7je53mE37Y+jEJxpRUlCKFmZUDuYkJ8i5HmO0SnaCnEGqNELaBkoIFnY3aE2Gw==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.10.1",
-        "@vue/babel-preset-app": "4.4.1",
-        "@vue/cli-shared-utils": "4.4.1",
-        "babel-loader": "8.1.0",
-        "cache-loader": "4.1.0",
-        "thread-loader": "2.1.3",
-        "webpack": "4.43.0"
+        "@babel/core": "^7.9.6",
+        "@vue/babel-preset-app": "^4.4.1",
+        "@vue/cli-shared-utils": "^4.4.1",
+        "babel-loader": "^8.1.0",
+        "cache-loader": "^4.1.0",
+        "thread-loader": "^2.1.3",
+        "webpack": "^4.0.0"
       }
     },
     "@vue/cli-plugin-eslint": {
@@ -2364,12 +2364,12 @@
       "integrity": "sha512-T+9+q44iajQEbe59z6Io3otFOsWnPOEVU+/hrDyC6aOToJbQo6P4VacByDDcuGYENAjAd8ENLSt18TaPNSIyRw==",
       "dev": true,
       "requires": {
-        "@vue/cli-shared-utils": "4.4.1",
-        "eslint-loader": "2.2.1",
-        "globby": "9.2.0",
-        "inquirer": "7.1.0",
-        "webpack": "4.43.0",
-        "yorkie": "2.0.0"
+        "@vue/cli-shared-utils": "^4.4.1",
+        "eslint-loader": "^2.2.1",
+        "globby": "^9.2.0",
+        "inquirer": "^7.1.0",
+        "webpack": "^4.0.0",
+        "yorkie": "^2.0.0"
       }
     },
     "@vue/cli-plugin-router": {
@@ -2378,7 +2378,7 @@
       "integrity": "sha512-kCSsJG7pjDvCJDjGtcCI5l0UjmqwNigOR41RkeGSjSUvzV4ArSniXjFqrOmtpMp36S5xCtwtt9MFm/K4fCubkQ==",
       "dev": true,
       "requires": {
-        "@vue/cli-shared-utils": "4.4.1"
+        "@vue/cli-shared-utils": "^4.4.1"
       }
     },
     "@vue/cli-plugin-vuex": {
@@ -2393,58 +2393,58 @@
       "integrity": "sha512-DVV0zr5Sw7pzdm3z3PRrfqihLgoJP/d9AgNFcSSQF/J9Gtvjf1t0PTJJFeLANHSL3kDWte+3kjc22sXayu0BJQ==",
       "dev": true,
       "requires": {
-        "@intervolga/optimize-cssnano-plugin": "1.0.6",
-        "@soda/friendly-errors-webpack-plugin": "1.7.1",
-        "@soda/get-current-script": "1.0.0",
-        "@vue/cli-overlay": "4.4.1",
-        "@vue/cli-plugin-router": "4.4.1",
-        "@vue/cli-plugin-vuex": "4.4.1",
-        "@vue/cli-shared-utils": "4.4.1",
-        "@vue/component-compiler-utils": "3.1.2",
-        "@vue/preload-webpack-plugin": "1.1.1",
-        "@vue/web-component-wrapper": "1.2.0",
-        "acorn": "7.2.0",
-        "acorn-walk": "7.1.1",
-        "address": "1.1.2",
-        "autoprefixer": "9.8.0",
-        "browserslist": "4.12.0",
-        "cache-loader": "4.1.0",
-        "case-sensitive-paths-webpack-plugin": "2.3.0",
-        "cli-highlight": "2.1.4",
-        "clipboardy": "2.3.0",
-        "cliui": "6.0.0",
-        "copy-webpack-plugin": "5.1.1",
-        "css-loader": "3.5.3",
-        "cssnano": "4.1.10",
-        "debug": "4.1.1",
-        "default-gateway": "5.0.5",
-        "dotenv": "8.2.0",
-        "dotenv-expand": "5.1.0",
-        "file-loader": "4.3.0",
-        "fs-extra": "7.0.1",
-        "globby": "9.2.0",
-        "hash-sum": "2.0.0",
-        "html-webpack-plugin": "3.2.0",
-        "launch-editor-middleware": "2.2.1",
-        "lodash.defaultsdeep": "4.6.1",
-        "lodash.mapvalues": "4.6.0",
-        "lodash.transform": "4.6.0",
-        "mini-css-extract-plugin": "0.9.0",
-        "minimist": "1.2.5",
-        "pnp-webpack-plugin": "1.6.4",
-        "portfinder": "1.0.26",
-        "postcss-loader": "3.0.0",
-        "ssri": "7.1.0",
-        "terser-webpack-plugin": "2.3.6",
-        "thread-loader": "2.1.3",
-        "url-loader": "2.3.0",
-        "vue-loader": "15.9.2",
-        "vue-style-loader": "4.1.2",
-        "webpack": "4.43.0",
-        "webpack-bundle-analyzer": "3.8.0",
-        "webpack-chain": "6.4.0",
-        "webpack-dev-server": "3.11.0",
-        "webpack-merge": "4.2.2"
+        "@intervolga/optimize-cssnano-plugin": "^1.0.5",
+        "@soda/friendly-errors-webpack-plugin": "^1.7.1",
+        "@soda/get-current-script": "^1.0.0",
+        "@vue/cli-overlay": "^4.4.1",
+        "@vue/cli-plugin-router": "^4.4.1",
+        "@vue/cli-plugin-vuex": "^4.4.1",
+        "@vue/cli-shared-utils": "^4.4.1",
+        "@vue/component-compiler-utils": "^3.1.2",
+        "@vue/preload-webpack-plugin": "^1.1.0",
+        "@vue/web-component-wrapper": "^1.2.0",
+        "acorn": "^7.2.0",
+        "acorn-walk": "^7.1.1",
+        "address": "^1.1.2",
+        "autoprefixer": "^9.8.0",
+        "browserslist": "^4.12.0",
+        "cache-loader": "^4.1.0",
+        "case-sensitive-paths-webpack-plugin": "^2.3.0",
+        "cli-highlight": "^2.1.4",
+        "clipboardy": "^2.3.0",
+        "cliui": "^6.0.0",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^3.5.3",
+        "cssnano": "^4.1.10",
+        "debug": "^4.1.1",
+        "default-gateway": "^5.0.5",
+        "dotenv": "^8.2.0",
+        "dotenv-expand": "^5.1.0",
+        "file-loader": "^4.2.0",
+        "fs-extra": "^7.0.1",
+        "globby": "^9.2.0",
+        "hash-sum": "^2.0.0",
+        "html-webpack-plugin": "^3.2.0",
+        "launch-editor-middleware": "^2.2.1",
+        "lodash.defaultsdeep": "^4.6.1",
+        "lodash.mapvalues": "^4.6.0",
+        "lodash.transform": "^4.6.0",
+        "mini-css-extract-plugin": "^0.9.0",
+        "minimist": "^1.2.5",
+        "pnp-webpack-plugin": "^1.6.4",
+        "portfinder": "^1.0.26",
+        "postcss-loader": "^3.0.0",
+        "ssri": "^7.1.0",
+        "terser-webpack-plugin": "^2.3.6",
+        "thread-loader": "^2.1.3",
+        "url-loader": "^2.2.0",
+        "vue-loader": "^15.9.2",
+        "vue-style-loader": "^4.1.2",
+        "webpack": "^4.0.0",
+        "webpack-bundle-analyzer": "^3.8.0",
+        "webpack-chain": "^6.4.0",
+        "webpack-dev-server": "^3.11.0",
+        "webpack-merge": "^4.2.2"
       },
       "dependencies": {
         "acorn": {
@@ -2459,24 +2459,24 @@
           "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
           "dev": true,
           "requires": {
-            "chownr": "1.1.4",
-            "figgy-pudding": "3.5.2",
-            "fs-minipass": "2.1.0",
-            "glob": "7.1.6",
-            "graceful-fs": "4.2.4",
-            "infer-owner": "1.0.4",
-            "lru-cache": "5.1.1",
-            "minipass": "3.1.3",
-            "minipass-collect": "1.0.2",
-            "minipass-flush": "1.0.5",
-            "minipass-pipeline": "1.2.3",
-            "mkdirp": "0.5.5",
-            "move-concurrently": "1.0.1",
-            "p-map": "3.0.0",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.7.1",
-            "ssri": "7.1.0",
-            "unique-filename": "1.1.1"
+            "chownr": "^1.1.2",
+            "figgy-pudding": "^3.5.1",
+            "fs-minipass": "^2.0.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.2",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^5.1.1",
+            "minipass": "^3.0.0",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "p-map": "^3.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.7.1",
+            "ssri": "^7.0.0",
+            "unique-filename": "^1.1.1"
           }
         },
         "find-cache-dir": {
@@ -2485,9 +2485,9 @@
           "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "make-dir": "3.1.0",
-            "pkg-dir": "4.2.0"
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
           }
         },
         "find-up": {
@@ -2496,8 +2496,8 @@
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "locate-path": "5.0.0",
-            "path-exists": "4.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "locate-path": {
@@ -2506,7 +2506,7 @@
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
-            "p-locate": "4.1.0"
+            "p-locate": "^4.1.0"
           }
         },
         "make-dir": {
@@ -2515,7 +2515,7 @@
           "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
-            "semver": "6.3.0"
+            "semver": "^6.0.0"
           }
         },
         "p-limit": {
@@ -2524,7 +2524,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -2533,7 +2533,7 @@
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.2.0"
           }
         },
         "p-try": {
@@ -2554,7 +2554,7 @@
           "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
           "dev": true,
           "requires": {
-            "find-up": "4.1.0"
+            "find-up": "^4.0.0"
           }
         },
         "semver": {
@@ -2569,7 +2569,7 @@
           "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
           "dev": true,
           "requires": {
-            "randombytes": "2.1.0"
+            "randombytes": "^2.1.0"
           }
         },
         "source-map": {
@@ -2584,8 +2584,8 @@
           "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.5.2",
-            "minipass": "3.1.3"
+            "figgy-pudding": "^3.5.1",
+            "minipass": "^3.1.1"
           }
         },
         "terser-webpack-plugin": {
@@ -2594,15 +2594,15 @@
           "integrity": "sha512-I8IDsQwZrqjdmOicNeE8L/MhwatAap3mUrtcAKJuilsemUNcX+Hier/eAzwStVqhlCxq0aG3ni9bK/0BESXkTg==",
           "dev": true,
           "requires": {
-            "cacache": "13.0.1",
-            "find-cache-dir": "3.3.1",
-            "jest-worker": "25.5.0",
-            "p-limit": "2.3.0",
-            "schema-utils": "2.7.0",
-            "serialize-javascript": "3.1.0",
-            "source-map": "0.6.1",
-            "terser": "4.7.0",
-            "webpack-sources": "1.4.3"
+            "cacache": "^13.0.1",
+            "find-cache-dir": "^3.3.1",
+            "jest-worker": "^25.4.0",
+            "p-limit": "^2.3.0",
+            "schema-utils": "^2.6.6",
+            "serialize-javascript": "^3.0.0",
+            "source-map": "^0.6.1",
+            "terser": "^4.6.12",
+            "webpack-sources": "^1.4.3"
           }
         }
       }
@@ -2613,19 +2613,19 @@
       "integrity": "sha512-teevHgI7XUsKVMOncx3M+6iLjO28woGfRwgUG4hR83moVBHQe5x2OCr2i5t/58bwpv269RD5RYXBQCGtIXuxZw==",
       "dev": true,
       "requires": {
-        "@hapi/joi": "15.1.1",
-        "chalk": "2.4.2",
-        "execa": "1.0.0",
-        "launch-editor": "2.2.1",
-        "lru-cache": "5.1.1",
-        "node-ipc": "9.1.1",
-        "open": "6.4.0",
-        "ora": "3.4.0",
-        "read-pkg": "5.2.0",
-        "request": "2.88.2",
-        "request-promise-native": "1.0.8",
-        "semver": "6.3.0",
-        "strip-ansi": "6.0.0"
+        "@hapi/joi": "^15.0.1",
+        "chalk": "^2.4.2",
+        "execa": "^1.0.0",
+        "launch-editor": "^2.2.1",
+        "lru-cache": "^5.1.1",
+        "node-ipc": "^9.1.1",
+        "open": "^6.3.0",
+        "ora": "^3.4.0",
+        "read-pkg": "^5.1.1",
+        "request": "^2.88.2",
+        "request-promise-native": "^1.0.8",
+        "semver": "^6.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "semver": {
@@ -2642,15 +2642,15 @@
       "integrity": "sha512-QLq9z8m79mCinpaEeSURhnNCN6djxpHw0lpP/bodMlt5kALfONpryMthvnrQOlTcIKoF+VoPi+lPHUYeDFPXug==",
       "dev": true,
       "requires": {
-        "consolidate": "0.15.1",
-        "hash-sum": "1.0.2",
-        "lru-cache": "4.1.5",
-        "merge-source-map": "1.1.0",
-        "postcss": "7.0.31",
-        "postcss-selector-parser": "6.0.2",
-        "prettier": "1.19.1",
-        "source-map": "0.6.1",
-        "vue-template-es2015-compiler": "1.9.1"
+        "consolidate": "^0.15.1",
+        "hash-sum": "^1.0.2",
+        "lru-cache": "^4.1.2",
+        "merge-source-map": "^1.1.0",
+        "postcss": "^7.0.14",
+        "postcss-selector-parser": "^6.0.2",
+        "prettier": "^1.18.2",
+        "source-map": "~0.6.1",
+        "vue-template-es2015-compiler": "^1.9.0"
       },
       "dependencies": {
         "hash-sum": {
@@ -2665,8 +2665,8 @@
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "source-map": {
@@ -2689,7 +2689,7 @@
       "integrity": "sha512-wFQmv45c3ige5EA+ngijq40YpVcIkAy0Lihupnsnd1Dao5CBbPyfCzqtejFLZX1EwH/kCJdpz3t6s+5wd3+KxQ==",
       "dev": true,
       "requires": {
-        "eslint-config-prettier": "6.11.0"
+        "eslint-config-prettier": "^6.0.0"
       }
     },
     "@vue/preload-webpack-plugin": {
@@ -2781,7 +2781,7 @@
       "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
       "dev": true,
       "requires": {
-        "@xtuc/ieee754": "1.2.0"
+        "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
@@ -2884,8 +2884,8 @@
       "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
       "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
       "requires": {
-        "@types/node": "14.0.5",
-        "tslib": "1.13.0"
+        "@types/node": ">=6",
+        "tslib": "^1.9.3"
       }
     },
     "@wry/equality": {
@@ -2893,7 +2893,7 @@
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
       "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
       "requires": {
-        "tslib": "1.13.0"
+        "tslib": "^1.9.3"
       }
     },
     "@xtuc/ieee754": {
@@ -2920,7 +2920,7 @@
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.27",
+        "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
     },
@@ -2947,7 +2947,7 @@
       "resolved": "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.1.0.tgz",
       "integrity": "sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==",
       "requires": {
-        "object-assign": "4.1.1"
+        "object-assign": "4.x"
       }
     },
     "address": {
@@ -2962,8 +2962,8 @@
       "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
       "dev": true,
       "requires": {
-        "clean-stack": "2.2.0",
-        "indent-string": "4.0.0"
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
       }
     },
     "ajv": {
@@ -2972,10 +2972,10 @@
       "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "3.1.1",
-        "fast-json-stable-stringify": "2.1.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-errors": {
@@ -3002,7 +3002,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3023,8 +3023,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -3033,7 +3033,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -3050,7 +3050,7 @@
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "dev": true,
       "requires": {
-        "type-fest": "0.11.0"
+        "type-fest": "^0.11.0"
       },
       "dependencies": {
         "type-fest": {
@@ -3078,7 +3078,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "ansicolors": {
@@ -3092,35 +3092,35 @@
       "resolved": "https://registry.npmjs.org/ant-design-vue/-/ant-design-vue-1.6.2.tgz",
       "integrity": "sha512-VEwWomHxY+0rt0RKRd4FqrW+udCr7cpFt0GwVOCJPwIdulkZkB3GjK64GslEl9XtBp/rKzcorfAx4t1ues6Izg==",
       "requires": {
-        "@ant-design/icons": "2.1.1",
-        "@ant-design/icons-vue": "2.0.0",
-        "add-dom-event-listener": "1.1.0",
-        "array-tree-filter": "2.1.0",
-        "async-validator": "3.3.0",
-        "babel-helper-vue-jsx-merge-props": "2.0.3",
-        "babel-runtime": "6.26.0",
-        "classnames": "2.2.6",
-        "component-classes": "1.2.6",
-        "dom-align": "1.12.0",
-        "dom-closest": "0.2.0",
-        "dom-scroll-into-view": "2.0.1",
-        "enquire.js": "2.1.6",
-        "intersperse": "1.0.0",
-        "is-mobile": "2.2.1",
-        "is-negative-zero": "2.0.0",
-        "ismobilejs": "1.1.1",
-        "json2mq": "0.2.0",
-        "lodash": "4.17.15",
-        "moment": "2.26.0",
-        "mutationobserver-shim": "0.3.5",
-        "node-emoji": "1.10.0",
-        "omit.js": "1.0.2",
-        "raf": "3.4.1",
-        "resize-observer-polyfill": "1.5.1",
-        "shallow-equal": "1.2.1",
-        "shallowequal": "1.1.0",
-        "vue-ref": "2.0.0",
-        "warning": "4.0.3"
+        "@ant-design/icons": "^2.1.1",
+        "@ant-design/icons-vue": "^2.0.0",
+        "add-dom-event-listener": "^1.0.2",
+        "array-tree-filter": "^2.1.0",
+        "async-validator": "^3.0.3",
+        "babel-helper-vue-jsx-merge-props": "^2.0.3",
+        "babel-runtime": "6.x",
+        "classnames": "^2.2.5",
+        "component-classes": "^1.2.6",
+        "dom-align": "^1.10.4",
+        "dom-closest": "^0.2.0",
+        "dom-scroll-into-view": "^2.0.0",
+        "enquire.js": "^2.1.6",
+        "intersperse": "^1.0.0",
+        "is-mobile": "^2.2.1",
+        "is-negative-zero": "^2.0.0",
+        "ismobilejs": "^1.0.0",
+        "json2mq": "^0.2.0",
+        "lodash": "^4.17.5",
+        "moment": "^2.21.0",
+        "mutationobserver-shim": "^0.3.2",
+        "node-emoji": "^1.10.0",
+        "omit.js": "^1.0.0",
+        "raf": "^3.4.0",
+        "resize-observer-polyfill": "^1.5.1",
+        "shallow-equal": "^1.0.0",
+        "shallowequal": "^1.0.2",
+        "vue-ref": "^2.0.0",
+        "warning": "^4.0.0"
       }
     },
     "any-observable": {
@@ -3142,8 +3142,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "normalize-path": "3.0.0",
-        "picomatch": "2.2.2"
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "apollo": {
@@ -3152,7 +3152,7 @@
       "integrity": "sha512-dtgkWQi+x36mUFKq3HSSANrVMycyrpeGR/cJsisogzAkJvqFS7Pk2CWCNlrOV9HU/UmHBi0ecBLC5xOI7izBUw==",
       "dev": true,
       "requires": {
-        "@apollographql/apollo-tools": "0.4.8",
+        "@apollographql/apollo-tools": "^0.4.8",
         "@oclif/command": "1.6.1",
         "@oclif/config": "1.15.1",
         "@oclif/errors": "1.2.2",
@@ -3161,14 +3161,14 @@
         "@oclif/plugin-not-found": "1.2.4",
         "@oclif/plugin-plugins": "1.7.9",
         "@oclif/plugin-warn-if-update-available": "1.7.0",
-        "apollo-codegen-core": "0.37.0",
-        "apollo-codegen-flow": "0.35.0",
-        "apollo-codegen-scala": "0.36.0",
-        "apollo-codegen-swift": "0.37.0",
-        "apollo-codegen-typescript": "0.37.0",
-        "apollo-env": "0.6.5",
-        "apollo-graphql": "0.4.4",
-        "apollo-language-server": "1.22.0",
+        "apollo-codegen-core": "^0.37.0",
+        "apollo-codegen-flow": "^0.35.0",
+        "apollo-codegen-scala": "^0.36.0",
+        "apollo-codegen-swift": "^0.37.0",
+        "apollo-codegen-typescript": "^0.37.0",
+        "apollo-env": "^0.6.5",
+        "apollo-graphql": "^0.4.4",
+        "apollo-language-server": "^1.22.0",
         "chalk": "2.4.2",
         "cli-ux": "5.4.6",
         "env-ci": "3.2.2",
@@ -3176,7 +3176,7 @@
         "git-parse": "1.0.4",
         "git-rev-sync": "2.0.0",
         "glob": "7.1.5",
-        "graphql": "14.6.0",
+        "graphql": "14.0.2 - 14.2.0 || ^14.3.1",
         "graphql-tag": "2.10.3",
         "listr": "0.14.3",
         "lodash.identity": "3.0.0",
@@ -3195,12 +3195,12 @@
           "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.4",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graphql": {
@@ -3209,7 +3209,7 @@
           "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
           "dev": true,
           "requires": {
-            "iterall": "1.3.0"
+            "iterall": "^1.2.2"
           }
         },
         "moment": {
@@ -3224,7 +3224,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -3234,8 +3234,8 @@
       "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
       "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
       "requires": {
-        "apollo-utilities": "1.3.4",
-        "tslib": "1.13.0"
+        "apollo-utilities": "^1.3.4",
+        "tslib": "^1.10.0"
       }
     },
     "apollo-cache-control": {
@@ -3244,8 +3244,8 @@
       "integrity": "sha512-dmRnQ9AXGw2SHahVGLzB/p4UW/taFBAJxifxubp8hqY5p9qdlSu4MPRq8zvV2ULMYf50rBtZyC4C+dZLqmHuHQ==",
       "dev": true,
       "requires": {
-        "apollo-server-env": "2.4.4",
-        "apollo-server-plugin-base": "0.9.0"
+        "apollo-server-env": "^2.4.4",
+        "apollo-server-plugin-base": "^0.9.0"
       }
     },
     "apollo-cache-inmemory": {
@@ -3253,11 +3253,11 @@
       "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
       "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
       "requires": {
-        "apollo-cache": "1.3.5",
-        "apollo-utilities": "1.3.4",
-        "optimism": "0.10.3",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.13.0"
+        "apollo-cache": "^1.3.5",
+        "apollo-utilities": "^1.3.4",
+        "optimism": "^0.10.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
       }
     },
     "apollo-client": {
@@ -3265,14 +3265,14 @@
       "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
       "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
       "requires": {
-        "@types/zen-observable": "0.8.0",
+        "@types/zen-observable": "^0.8.0",
         "apollo-cache": "1.3.5",
-        "apollo-link": "1.2.14",
+        "apollo-link": "^1.0.0",
         "apollo-utilities": "1.3.4",
-        "symbol-observable": "1.2.0",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.13.0",
-        "zen-observable": "0.8.15"
+        "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.0"
       }
     },
     "apollo-codegen-core": {
@@ -3282,13 +3282,13 @@
       "dev": true,
       "requires": {
         "@babel/generator": "7.9.6",
-        "@babel/parser": "7.10.1",
+        "@babel/parser": "^7.1.3",
         "@babel/types": "7.9.6",
-        "apollo-env": "0.6.5",
-        "apollo-language-server": "1.22.0",
-        "ast-types": "0.13.3",
-        "common-tags": "1.8.0",
-        "recast": "0.19.1"
+        "apollo-env": "^0.6.5",
+        "apollo-language-server": "^1.22.0",
+        "ast-types": "^0.13.0",
+        "common-tags": "^1.5.1",
+        "recast": "^0.19.0"
       },
       "dependencies": {
         "@babel/generator": {
@@ -3297,10 +3297,10 @@
           "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "7.9.6",
-            "jsesc": "2.5.2",
-            "lodash": "4.17.15",
-            "source-map": "0.5.7"
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
           }
         },
         "@babel/types": {
@@ -3309,9 +3309,9 @@
           "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "7.10.1",
-            "lodash": "4.17.15",
-            "to-fast-properties": "2.0.0"
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
           }
         }
       }
@@ -3324,10 +3324,10 @@
       "requires": {
         "@babel/generator": "7.9.6",
         "@babel/types": "7.9.6",
-        "apollo-codegen-core": "0.37.0",
-        "change-case": "3.1.0",
-        "common-tags": "1.8.0",
-        "inflected": "2.0.4"
+        "apollo-codegen-core": "^0.37.0",
+        "change-case": "^3.0.1",
+        "common-tags": "^1.5.1",
+        "inflected": "^2.0.3"
       },
       "dependencies": {
         "@babel/generator": {
@@ -3336,10 +3336,10 @@
           "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "7.9.6",
-            "jsesc": "2.5.2",
-            "lodash": "4.17.15",
-            "source-map": "0.5.7"
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
           }
         },
         "@babel/types": {
@@ -3348,9 +3348,9 @@
           "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "7.10.1",
-            "lodash": "4.17.15",
-            "to-fast-properties": "2.0.0"
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
           }
         }
       }
@@ -3361,10 +3361,10 @@
       "integrity": "sha512-HwKXQwpGblLKUFyZb5B3Culym+Uo9yE3oFoHzMVClIG4iwxqkrwwctfXyc4aLEVmVXT9wDPAiX8xKo8TQiTnng==",
       "dev": true,
       "requires": {
-        "apollo-codegen-core": "0.37.0",
-        "change-case": "3.1.0",
-        "common-tags": "1.8.0",
-        "inflected": "2.0.4"
+        "apollo-codegen-core": "^0.37.0",
+        "change-case": "^3.0.1",
+        "common-tags": "^1.5.1",
+        "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-swift": {
@@ -3373,10 +3373,10 @@
       "integrity": "sha512-jaYHiDoQQNGyEF1tHlUk+sjRAX8yBF5hrG4T9GE1OMEwQ8Q57FQx+N1GvkCxNIQlYFbfJFsAzhTjwfp1bPxGnA==",
       "dev": true,
       "requires": {
-        "apollo-codegen-core": "0.37.0",
-        "change-case": "3.1.0",
-        "common-tags": "1.8.0",
-        "inflected": "2.0.4"
+        "apollo-codegen-core": "^0.37.0",
+        "change-case": "^3.0.1",
+        "common-tags": "^1.5.1",
+        "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-typescript": {
@@ -3387,10 +3387,10 @@
       "requires": {
         "@babel/generator": "7.9.6",
         "@babel/types": "7.9.6",
-        "apollo-codegen-core": "0.37.0",
-        "change-case": "3.1.0",
-        "common-tags": "1.8.0",
-        "inflected": "2.0.4"
+        "apollo-codegen-core": "^0.37.0",
+        "change-case": "^3.0.1",
+        "common-tags": "^1.5.1",
+        "inflected": "^2.0.3"
       },
       "dependencies": {
         "@babel/generator": {
@@ -3399,10 +3399,10 @@
           "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "7.9.6",
-            "jsesc": "2.5.2",
-            "lodash": "4.17.15",
-            "source-map": "0.5.7"
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
           }
         },
         "@babel/types": {
@@ -3411,9 +3411,9 @@
           "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "7.10.1",
-            "lodash": "4.17.15",
-            "to-fast-properties": "2.0.0"
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
           }
         }
       }
@@ -3424,8 +3424,8 @@
       "integrity": "sha512-h++/jQAY7GA+4TBM+7ezvctFmmGNLrAPf51KsagZj+NkT9qvxp585rdsuatynVbSl59toPK2EuVmc6ilmQHf+g==",
       "dev": true,
       "requires": {
-        "apollo-server-caching": "0.5.1",
-        "apollo-server-env": "2.4.4"
+        "apollo-server-caching": "^0.5.1",
+        "apollo-server-env": "^2.4.4"
       }
     },
     "apollo-engine-reporting": {
@@ -3434,15 +3434,15 @@
       "integrity": "sha512-FvNwORsh3nxEfvQqd2xbd468a0q/R3kYar/Bk6YQdBX5qwqUhqmOcOSxLFk8Zb77HpwHij5CPpPWJb53TU1zcA==",
       "dev": true,
       "requires": {
-        "apollo-engine-reporting-protobuf": "0.5.1",
-        "apollo-graphql": "0.4.4",
-        "apollo-server-caching": "0.5.1",
-        "apollo-server-env": "2.4.4",
-        "apollo-server-errors": "2.4.1",
-        "apollo-server-plugin-base": "0.9.0",
-        "apollo-server-types": "0.5.0",
-        "async-retry": "1.3.1",
-        "uuid": "8.1.0"
+        "apollo-engine-reporting-protobuf": "^0.5.1",
+        "apollo-graphql": "^0.4.0",
+        "apollo-server-caching": "^0.5.1",
+        "apollo-server-env": "^2.4.4",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-plugin-base": "^0.9.0",
+        "apollo-server-types": "^0.5.0",
+        "async-retry": "^1.2.1",
+        "uuid": "^8.0.0"
       },
       "dependencies": {
         "uuid": {
@@ -3459,7 +3459,7 @@
       "integrity": "sha512-TSfr9iAaInV8dhXkesdcmqsthRkVcJkzznmiM+1Ob/GScK7r6hBYCjVDt2613EHAg9SUzTOltIKlGD+N+GJRUw==",
       "dev": true,
       "requires": {
-        "@apollo/protobufjs": "1.0.4"
+        "@apollo/protobufjs": "^1.0.3"
       }
     },
     "apollo-env": {
@@ -3469,9 +3469,9 @@
       "dev": true,
       "requires": {
         "@types/node-fetch": "2.5.7",
-        "core-js": "3.6.5",
-        "node-fetch": "2.6.0",
-        "sha.js": "2.4.11"
+        "core-js": "^3.0.1",
+        "node-fetch": "^2.2.0",
+        "sha.js": "^2.4.11"
       }
     },
     "apollo-graphql": {
@@ -3480,8 +3480,8 @@
       "integrity": "sha512-i012iRKT5nfsOaNMx4MTwHw2jrlyaF1zikpejxsGHsKIf3OngGvGh3pyw20bEmwj413OrNQpRxvvIz5A7W/8xw==",
       "dev": true,
       "requires": {
-        "apollo-env": "0.6.5",
-        "lodash.sortby": "4.7.0"
+        "apollo-env": "^0.6.5",
+        "lodash.sortby": "^4.7.0"
       }
     },
     "apollo-language-server": {
@@ -3491,29 +3491,29 @@
       "dev": true,
       "requires": {
         "@apollo/federation": "0.16.0",
-        "@apollographql/apollo-tools": "0.4.8",
-        "@apollographql/graphql-language-service-interface": "2.0.2",
-        "@endemolshinegroup/cosmiconfig-typescript-loader": "1.0.1",
-        "apollo-datasource": "0.7.1",
-        "apollo-env": "0.6.5",
-        "apollo-graphql": "0.4.4",
-        "apollo-link": "1.2.14",
-        "apollo-link-context": "1.0.20",
-        "apollo-link-error": "1.1.13",
-        "apollo-link-http": "1.5.17",
-        "apollo-server-errors": "2.4.1",
-        "await-to-js": "2.1.1",
-        "core-js": "3.6.5",
-        "cosmiconfig": "5.2.1",
-        "dotenv": "8.2.0",
-        "glob": "7.1.6",
-        "graphql": "14.6.0",
-        "graphql-tag": "2.10.3",
-        "lodash.debounce": "4.0.8",
-        "lodash.merge": "4.6.2",
-        "minimatch": "3.0.4",
+        "@apollographql/apollo-tools": "^0.4.8",
+        "@apollographql/graphql-language-service-interface": "^2.0.2",
+        "@endemolshinegroup/cosmiconfig-typescript-loader": "^1.0.0",
+        "apollo-datasource": "^0.7.0",
+        "apollo-env": "^0.6.5",
+        "apollo-graphql": "^0.4.4",
+        "apollo-link": "^1.2.3",
+        "apollo-link-context": "^1.0.9",
+        "apollo-link-error": "^1.1.1",
+        "apollo-link-http": "^1.5.5",
+        "apollo-server-errors": "^2.0.2",
+        "await-to-js": "^2.0.1",
+        "core-js": "^3.0.1",
+        "cosmiconfig": "^5.0.6",
+        "dotenv": "^8.0.0",
+        "glob": "^7.1.3",
+        "graphql": "14.0.2 - 14.2.0 || ^14.3.1",
+        "graphql-tag": "^2.10.1",
+        "lodash.debounce": "^4.0.8",
+        "lodash.merge": "^4.6.1",
+        "minimatch": "^3.0.4",
         "moment": "2.25.3",
-        "vscode-languageserver": "5.2.1",
+        "vscode-languageserver": "^5.1.0",
         "vscode-uri": "1.0.6"
       },
       "dependencies": {
@@ -3523,7 +3523,7 @@
           "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
           "dev": true,
           "requires": {
-            "iterall": "1.3.0"
+            "iterall": "^1.2.2"
           }
         },
         "moment": {
@@ -3539,10 +3539,10 @@
       "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
       "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
       "requires": {
-        "apollo-utilities": "1.3.4",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.13.0",
-        "zen-observable-ts": "0.8.21"
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.21"
       }
     },
     "apollo-link-context": {
@@ -3551,8 +3551,8 @@
       "integrity": "sha512-MLLPYvhzNb8AglNsk2NcL9AvhO/Vc9hn2ZZuegbhRHGet3oGr0YH9s30NS9+ieoM0sGT11p7oZ6oAILM/kiRBA==",
       "dev": true,
       "requires": {
-        "apollo-link": "1.2.14",
-        "tslib": "1.13.0"
+        "apollo-link": "^1.2.14",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-error": {
@@ -3561,9 +3561,9 @@
       "integrity": "sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==",
       "dev": true,
       "requires": {
-        "apollo-link": "1.2.14",
-        "apollo-link-http-common": "0.2.16",
-        "tslib": "1.13.0"
+        "apollo-link": "^1.2.14",
+        "apollo-link-http-common": "^0.2.16",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-http": {
@@ -3571,9 +3571,9 @@
       "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
       "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
       "requires": {
-        "apollo-link": "1.2.14",
-        "apollo-link-http-common": "0.2.16",
-        "tslib": "1.13.0"
+        "apollo-link": "^1.2.14",
+        "apollo-link-http-common": "^0.2.16",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-http-common": {
@@ -3581,9 +3581,9 @@
       "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
       "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
       "requires": {
-        "apollo-link": "1.2.14",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.13.0"
+        "apollo-link": "^1.2.14",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-persisted-queries": {
@@ -3592,8 +3592,8 @@
       "integrity": "sha512-YL7XBu/5QsSbbYaWUXgm87T2Hn/2AQZk5Wr8CLXGDr3Wl3E/TRhBhKgQQTly9xhaTi7jgBO+AeIyTH5wCBHA9w==",
       "dev": true,
       "requires": {
-        "apollo-link": "1.2.14",
-        "hash.js": "1.1.7"
+        "apollo-link": "^1.2.1",
+        "hash.js": "^1.1.3"
       }
     },
     "apollo-link-state": {
@@ -3602,8 +3602,8 @@
       "integrity": "sha512-xMPcAfuiPVYXaLwC6oJFIZrKgV3GmdO31Ag2eufRoXpvT0AfJZjdaPB4450Nu9TslHRePN9A3quxNueILlQxlw==",
       "dev": true,
       "requires": {
-        "apollo-utilities": "1.3.4",
-        "graphql-anywhere": "4.2.7"
+        "apollo-utilities": "^1.0.8",
+        "graphql-anywhere": "^4.1.0-alpha.0"
       }
     },
     "apollo-link-ws": {
@@ -3612,8 +3612,8 @@
       "integrity": "sha512-mjSFPlQxmoLArpHBeUb2Xj+2HDYeTaJqFGOqQ+I8NVJxgL9lJe84PDWcPah/yMLv3rB7QgBDSuZ0xoRFBPlySw==",
       "dev": true,
       "requires": {
-        "apollo-link": "1.2.14",
-        "tslib": "1.13.0"
+        "apollo-link": "^1.2.14",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-server-caching": {
@@ -3622,7 +3622,7 @@
       "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
       "dev": true,
       "requires": {
-        "lru-cache": "5.1.1"
+        "lru-cache": "^5.0.0"
       }
     },
     "apollo-server-core": {
@@ -3631,28 +3631,28 @@
       "integrity": "sha512-8G6Aoz+k+ecuQco1KNLFbMrxhe/8uR4AOaOYEvT/N5m/6lrkPYzvBAxbpRIub5AxEwpBPcIrI452rR3PD9DItA==",
       "dev": true,
       "requires": {
-        "@apollographql/apollo-tools": "0.4.8",
+        "@apollographql/apollo-tools": "^0.4.3",
         "@apollographql/graphql-playground-html": "1.6.24",
-        "@types/graphql-upload": "8.0.3",
-        "@types/ws": "7.2.5",
-        "apollo-cache-control": "0.11.0",
-        "apollo-datasource": "0.7.1",
-        "apollo-engine-reporting": "2.0.0",
-        "apollo-server-caching": "0.5.1",
-        "apollo-server-env": "2.4.4",
-        "apollo-server-errors": "2.4.1",
-        "apollo-server-plugin-base": "0.9.0",
-        "apollo-server-types": "0.5.0",
-        "apollo-tracing": "0.11.0",
-        "fast-json-stable-stringify": "2.1.0",
-        "graphql-extensions": "0.12.2",
-        "graphql-tag": "2.10.3",
-        "graphql-tools": "4.0.8",
-        "graphql-upload": "8.1.0",
-        "loglevel": "1.6.8",
-        "sha.js": "2.4.11",
-        "subscriptions-transport-ws": "0.9.16",
-        "ws": "6.2.1"
+        "@types/graphql-upload": "^8.0.0",
+        "@types/ws": "^7.0.0",
+        "apollo-cache-control": "^0.11.0",
+        "apollo-datasource": "^0.7.1",
+        "apollo-engine-reporting": "^2.0.0",
+        "apollo-server-caching": "^0.5.1",
+        "apollo-server-env": "^2.4.4",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-plugin-base": "^0.9.0",
+        "apollo-server-types": "^0.5.0",
+        "apollo-tracing": "^0.11.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-extensions": "^0.12.2",
+        "graphql-tag": "^2.9.2",
+        "graphql-tools": "^4.0.0",
+        "graphql-upload": "^8.0.2",
+        "loglevel": "^1.6.7",
+        "sha.js": "^2.4.11",
+        "subscriptions-transport-ws": "^0.9.11",
+        "ws": "^6.0.0"
       }
     },
     "apollo-server-env": {
@@ -3661,8 +3661,8 @@
       "integrity": "sha512-c2oddDS3lwAl6QNCIKCLEzt/dF9M3/tjjYRVdxOVN20TidybI7rAbnT4QOzf4tORnGXtiznEAvr/Kc9ahhKADg==",
       "dev": true,
       "requires": {
-        "node-fetch": "2.6.0",
-        "util.promisify": "1.0.1"
+        "node-fetch": "^2.1.2",
+        "util.promisify": "^1.0.0"
       }
     },
     "apollo-server-errors": {
@@ -3678,21 +3678,21 @@
       "dev": true,
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
-        "@types/accepts": "1.3.5",
+        "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.0",
-        "@types/cors": "2.8.6",
+        "@types/cors": "^2.8.4",
         "@types/express": "4.17.4",
-        "accepts": "1.3.7",
-        "apollo-server-core": "2.14.2",
-        "apollo-server-types": "0.5.0",
-        "body-parser": "1.19.0",
-        "cors": "2.8.5",
-        "express": "4.17.1",
-        "graphql-subscriptions": "1.1.0",
-        "graphql-tools": "4.0.8",
-        "parseurl": "1.3.3",
-        "subscriptions-transport-ws": "0.9.16",
-        "type-is": "1.6.18"
+        "accepts": "^1.3.5",
+        "apollo-server-core": "^2.14.2",
+        "apollo-server-types": "^0.5.0",
+        "body-parser": "^1.18.3",
+        "cors": "^2.8.4",
+        "express": "^4.17.1",
+        "graphql-subscriptions": "^1.0.0",
+        "graphql-tools": "^4.0.0",
+        "parseurl": "^1.3.2",
+        "subscriptions-transport-ws": "^0.9.16",
+        "type-is": "^1.6.16"
       }
     },
     "apollo-server-plugin-base": {
@@ -3701,7 +3701,7 @@
       "integrity": "sha512-LWcPrsy2+xqwlNseh/QaGa/MPNopS8c4qGgh0g0cAn0lZBRrJ9Yab7dq+iQ6vdUBwIhUWYN6s9dwUWCZw2SL8g==",
       "dev": true,
       "requires": {
-        "apollo-server-types": "0.5.0"
+        "apollo-server-types": "^0.5.0"
       }
     },
     "apollo-server-types": {
@@ -3710,9 +3710,9 @@
       "integrity": "sha512-zhtsqqqfdeoJQAfc41Sy6WnnBVxKNgZ34BKXf/Q+kXmw7rbZ/B5SG3SJMvj1iFsbzZxILmWdUsE9aD20lEr0bg==",
       "dev": true,
       "requires": {
-        "apollo-engine-reporting-protobuf": "0.5.1",
-        "apollo-server-caching": "0.5.1",
-        "apollo-server-env": "2.4.4"
+        "apollo-engine-reporting-protobuf": "^0.5.1",
+        "apollo-server-caching": "^0.5.1",
+        "apollo-server-env": "^2.4.4"
       }
     },
     "apollo-tracing": {
@@ -3721,8 +3721,8 @@
       "integrity": "sha512-I9IFb/8lkBW8ZwOAi4LEojfT7dMfUSkpnV8LHQI8Rcj0HtzL9HObQ3woBmzyGHdGHLFuD/6/VHyFD67SesSrJg==",
       "dev": true,
       "requires": {
-        "apollo-server-env": "2.4.4",
-        "apollo-server-plugin-base": "0.9.0"
+        "apollo-server-env": "^2.4.4",
+        "apollo-server-plugin-base": "^0.9.0"
       }
     },
     "apollo-upload-client": {
@@ -3731,10 +3731,10 @@
       "integrity": "sha512-JChTrBi1VSF8u6OPrkWUApJlyUvzwhw98kqRB3fSi7/CU6z0OUD42Mee9s5h8mfjKEfOanK6GNZhF4t2tIPXSw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.10.1",
-        "apollo-link": "1.2.14",
-        "apollo-link-http-common": "0.2.16",
-        "extract-files": "5.0.1"
+        "@babel/runtime": "^7.5.4",
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "extract-files": "^5.0.1"
       }
     },
     "apollo-utilities": {
@@ -3742,10 +3742,10 @@
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
       "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
       "requires": {
-        "@wry/equality": "0.1.11",
-        "fast-json-stable-stringify": "2.1.0",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.13.0"
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
       }
     },
     "aproba": {
@@ -3772,7 +3772,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -3810,7 +3810,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -3831,7 +3831,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "asn1.js": {
@@ -3840,9 +3840,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.9",
-        "inherits": "2.0.4",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       },
       "dependencies": {
         "bn.js": {
@@ -3859,7 +3859,7 @@
       "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
+        "object-assign": "^4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -3910,7 +3910,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.15"
+        "lodash": "^4.17.14"
       }
     },
     "async-each": {
@@ -3955,13 +3955,13 @@
       "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.13.2.tgz",
       "integrity": "sha512-gWlf+X3XhCT9JboYpGviflv0pHcaHFPGtkLXiebyJohHDKddiu2rZkezp9kZHEoXqxhtNqgWuuaXkcla5JtnXg==",
       "requires": {
-        "base64-js": "1.3.1",
-        "idtoken-verifier": "2.0.3",
-        "js-cookie": "2.2.1",
-        "qs": "6.9.4",
-        "superagent": "3.8.3",
-        "url-join": "4.0.1",
-        "winchan": "0.2.2"
+        "base64-js": "^1.3.0",
+        "idtoken-verifier": "^2.0.2",
+        "js-cookie": "^2.2.0",
+        "qs": "^6.7.0",
+        "superagent": "^3.8.3",
+        "url-join": "^4.0.1",
+        "winchan": "^0.2.2"
       },
       "dependencies": {
         "qs": {
@@ -3977,13 +3977,13 @@
       "integrity": "sha512-D96ZiIHXbDmU02dBaemyAg53ez+6F5yZmapmgKcjm35yEe1uVDYI8hGW3VYoGRaG290ZFf91YxHrR518vC0u/A==",
       "dev": true,
       "requires": {
-        "browserslist": "4.12.0",
-        "caniuse-lite": "1.0.30001066",
-        "chalk": "2.4.2",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "4.1.0"
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001061",
+        "chalk": "^2.4.2",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.30",
+        "postcss-value-parser": "^4.1.0"
       }
     },
     "await-to-js": {
@@ -4025,7 +4025,7 @@
           "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
           "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
           "requires": {
-            "debug": "3.1.0"
+            "debug": "=3.1.0"
           }
         },
         "ms": {
@@ -4041,12 +4041,12 @@
       "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.10.1",
-        "@babel/parser": "7.10.1",
-        "@babel/traverse": "7.10.1",
-        "@babel/types": "7.10.1",
-        "eslint-visitor-keys": "1.1.0",
-        "resolve": "1.17.0"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
       }
     },
     "babel-helper-vue-jsx-merge-props": {
@@ -4060,11 +4060,11 @@
       "integrity": "sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==",
       "dev": true,
       "requires": {
-        "find-cache-dir": "2.1.0",
-        "loader-utils": "1.4.0",
-        "mkdirp": "0.5.5",
-        "pify": "4.0.1",
-        "schema-utils": "2.7.0"
+        "find-cache-dir": "^2.1.0",
+        "loader-utils": "^1.4.0",
+        "mkdirp": "^0.5.3",
+        "pify": "^4.0.1",
+        "schema-utils": "^2.6.5"
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -4073,7 +4073,7 @@
       "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "dev": true,
       "requires": {
-        "object.assign": "4.1.0"
+        "object.assign": "^4.1.0"
       }
     },
     "babel-runtime": {
@@ -4081,8 +4081,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.6.11",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "core-js": {
@@ -4115,13 +4115,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.3.0",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.2",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -4130,7 +4130,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -4139,7 +4139,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -4148,7 +4148,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -4157,9 +4157,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.3"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -4181,7 +4181,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bfj": {
@@ -4190,10 +4190,10 @@
       "integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
       "dev": true,
       "requires": {
-        "bluebird": "3.7.2",
-        "check-types": "8.0.3",
-        "hoopy": "0.1.4",
-        "tryer": "1.0.1"
+        "bluebird": "^3.5.5",
+        "check-types": "^8.0.3",
+        "hoopy": "^0.1.4",
+        "tryer": "^1.0.1"
       }
     },
     "big.js": {
@@ -4238,15 +4238,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.1.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.7.0",
         "raw-body": "2.4.0",
-        "type-is": "1.6.18"
+        "type-is": "~1.6.17"
       },
       "dependencies": {
         "debug": {
@@ -4278,12 +4278,12 @@
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
-        "array-flatten": "2.1.2",
-        "deep-equal": "1.1.1",
-        "dns-equal": "1.0.0",
-        "dns-txt": "2.0.2",
-        "multicast-dns": "6.2.3",
-        "multicast-dns-service-types": "1.1.0"
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
       },
       "dependencies": {
         "array-flatten": {
@@ -4310,11 +4310,11 @@
       "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.15.0.tgz",
       "integrity": "sha512-ncxWkDG0mKFVot314wWKJELi+ESO7k6ngV//qvJFs9iVzlFI8Hx3rBVbpcPW2vrJ+0vitH8N2SOwn4fdQ3frMQ==",
       "requires": {
-        "@nuxt/opencollective": "0.3.0",
-        "bootstrap": "4.5.0",
-        "popper.js": "1.16.1",
-        "portal-vue": "2.1.7",
-        "vue-functional-data-merge": "3.1.0"
+        "@nuxt/opencollective": "^0.3.0",
+        "bootstrap": ">=4.5.0 <5.0.0",
+        "popper.js": "^1.16.1",
+        "portal-vue": "^2.1.7",
+        "vue-functional-data-merge": "^3.1.0"
       }
     },
     "boxen": {
@@ -4323,13 +4323,13 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.4.2",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.1"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4356,8 +4356,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -4366,7 +4366,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -4377,7 +4377,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -4387,16 +4387,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.3",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4405,7 +4405,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -4422,12 +4422,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -4436,9 +4436,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.2",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -4447,10 +4447,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.1",
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-rsa": {
@@ -4459,8 +4459,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.9",
-        "randombytes": "2.1.0"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       },
       "dependencies": {
         "bn.js": {
@@ -4477,15 +4477,15 @@
       "integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
       "dev": true,
       "requires": {
-        "bn.js": "5.1.2",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.5.2",
-        "inherits": "2.0.4",
-        "parse-asn1": "5.1.5",
-        "readable-stream": "3.6.0",
-        "safe-buffer": "5.2.1"
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.2",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -4494,9 +4494,9 @@
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "safe-buffer": {
@@ -4513,7 +4513,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.11"
+        "pako": "~1.0.5"
       }
     },
     "browserslist": {
@@ -4522,10 +4522,10 @@
       "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30001066",
-        "electron-to-chromium": "1.3.453",
-        "node-releases": "1.1.57",
-        "pkg-up": "2.0.0"
+        "caniuse-lite": "^1.0.30001043",
+        "electron-to-chromium": "^1.3.413",
+        "node-releases": "^1.1.53",
+        "pkg-up": "^2.0.0"
       }
     },
     "buffer": {
@@ -4534,9 +4534,9 @@
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.1",
-        "ieee754": "1.1.13",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-from": {
@@ -4596,21 +4596,21 @@
       "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
       "dev": true,
       "requires": {
-        "bluebird": "3.7.2",
-        "chownr": "1.1.4",
-        "figgy-pudding": "3.5.2",
-        "glob": "7.1.6",
-        "graceful-fs": "4.2.4",
-        "infer-owner": "1.0.4",
-        "lru-cache": "5.1.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.5",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.7.1",
-        "ssri": "6.0.1",
-        "unique-filename": "1.1.1",
-        "y18n": "4.0.0"
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
       }
     },
     "cache-base": {
@@ -4619,15 +4619,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.3.0",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.1",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.1",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "cache-loader": {
@@ -4636,12 +4636,12 @@
       "integrity": "sha512-ftOayxve0PwKzBF/GLsZNC9fJBXl8lkZE3TOsjkboHfVHVkL39iUEs1FO07A33mizmci5Dudt38UZrrYXDtbhw==",
       "dev": true,
       "requires": {
-        "buffer-json": "2.0.0",
-        "find-cache-dir": "3.3.1",
-        "loader-utils": "1.4.0",
-        "mkdirp": "0.5.5",
-        "neo-async": "2.6.1",
-        "schema-utils": "2.7.0"
+        "buffer-json": "^2.0.0",
+        "find-cache-dir": "^3.0.0",
+        "loader-utils": "^1.2.3",
+        "mkdirp": "^0.5.1",
+        "neo-async": "^2.6.1",
+        "schema-utils": "^2.0.0"
       },
       "dependencies": {
         "find-cache-dir": {
@@ -4650,9 +4650,9 @@
           "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "make-dir": "3.1.0",
-            "pkg-dir": "4.2.0"
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
           }
         },
         "find-up": {
@@ -4661,8 +4661,8 @@
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "locate-path": "5.0.0",
-            "path-exists": "4.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "locate-path": {
@@ -4671,7 +4671,7 @@
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
-            "p-locate": "4.1.0"
+            "p-locate": "^4.1.0"
           }
         },
         "make-dir": {
@@ -4680,7 +4680,7 @@
           "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
-            "semver": "6.3.0"
+            "semver": "^6.0.0"
           }
         },
         "p-limit": {
@@ -4689,7 +4689,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -4698,7 +4698,7 @@
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.2.0"
           }
         },
         "p-try": {
@@ -4719,7 +4719,7 @@
           "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
           "dev": true,
           "requires": {
-            "find-up": "4.1.0"
+            "find-up": "^4.0.0"
           }
         },
         "semver": {
@@ -4742,7 +4742,7 @@
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0"
+        "callsites": "^2.0.0"
       }
     },
     "caller-path": {
@@ -4751,7 +4751,7 @@
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
-        "caller-callsite": "2.0.0"
+        "caller-callsite": "^2.0.0"
       }
     },
     "callsites": {
@@ -4766,8 +4766,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -4782,10 +4782,10 @@
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.12.0",
-        "caniuse-lite": "1.0.30001066",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
       }
     },
     "caniuse-lite": {
@@ -4806,8 +4806,8 @@
       "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
       "dev": true,
       "requires": {
-        "ansicolors": "0.3.2",
-        "redeyed": "2.1.1"
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
       }
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -4827,9 +4827,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "change-case": {
@@ -4838,24 +4838,24 @@
       "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.0",
-        "constant-case": "2.0.0",
-        "dot-case": "2.1.1",
-        "header-case": "1.0.1",
-        "is-lower-case": "1.1.3",
-        "is-upper-case": "1.1.2",
-        "lower-case": "1.1.4",
-        "lower-case-first": "1.0.2",
-        "no-case": "2.3.2",
-        "param-case": "2.1.1",
-        "pascal-case": "2.0.1",
-        "path-case": "2.1.1",
-        "sentence-case": "2.1.1",
-        "snake-case": "2.1.0",
-        "swap-case": "1.1.2",
-        "title-case": "2.1.1",
-        "upper-case": "1.1.3",
-        "upper-case-first": "1.1.2"
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.3.2",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "chardet": {
@@ -4877,14 +4877,14 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "anymatch": "3.1.1",
-        "braces": "3.0.2",
-        "fsevents": "2.1.3",
-        "glob-parent": "5.1.1",
-        "is-binary-path": "2.1.0",
-        "is-glob": "4.0.1",
-        "normalize-path": "3.0.0",
-        "readdirp": "3.4.0"
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
       },
       "dependencies": {
         "braces": {
@@ -4894,7 +4894,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fill-range": "7.0.1"
+            "fill-range": "^7.0.1"
           }
         },
         "fill-range": {
@@ -4904,7 +4904,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "to-regex-range": "5.0.1"
+            "to-regex-range": "^5.0.1"
           }
         },
         "is-number": {
@@ -4921,7 +4921,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-number": "7.0.0"
+            "is-number": "^7.0.0"
           }
         }
       }
@@ -4938,7 +4938,7 @@
       "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "dev": true,
       "requires": {
-        "tslib": "1.13.0"
+        "tslib": "^1.9.0"
       }
     },
     "ci-info": {
@@ -4953,8 +4953,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "class-utils": {
@@ -4963,10 +4963,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -4975,7 +4975,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -4991,7 +4991,7 @@
       "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
       "dev": true,
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "~0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -5020,7 +5020,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-highlight": {
@@ -5029,12 +5029,12 @@
       "integrity": "sha512-s7Zofobm20qriqDoU9sXptQx0t2R9PEgac92mENNm7xaEe1hn71IIMsXMK+6encA6WRCWWxIGQbipr3q998tlQ==",
       "dev": true,
       "requires": {
-        "chalk": "3.0.0",
-        "highlight.js": "9.18.1",
-        "mz": "2.7.0",
-        "parse5": "5.1.1",
-        "parse5-htmlparser2-tree-adapter": "5.1.1",
-        "yargs": "15.3.1"
+        "chalk": "^3.0.0",
+        "highlight.js": "^9.6.0",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^5.1.1",
+        "yargs": "^15.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5043,8 +5043,8 @@
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "@types/color-name": "1.1.1",
-            "color-convert": "2.0.1"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "chalk": {
@@ -5053,8 +5053,8 @@
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
-            "ansi-styles": "4.2.1",
-            "supports-color": "7.1.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
         "color-convert": {
@@ -5063,7 +5063,7 @@
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.4"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
@@ -5084,7 +5084,7 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "4.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -5095,8 +5095,8 @@
       "integrity": "sha512-qRwBxLldMSfxB+YGFgNRaj5vyyHe1yMpVeDL79c+7puGujdKJHQHydgqXDcrkvQgJ5U/d3lpf6vffSoVVUftVQ==",
       "dev": true,
       "requires": {
-        "colors": "1.4.0",
-        "string-width": "4.2.0"
+        "colors": "^1.1.2",
+        "string-width": "^4.2.0"
       }
     },
     "cli-spinners": {
@@ -5112,7 +5112,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5127,7 +5127,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "slice-ansi": {
@@ -5142,9 +5142,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -5153,7 +5153,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -5164,32 +5164,32 @@
       "integrity": "sha512-EeiS2TzEndRVknCqE+8Ri8g0bsP617a1nq6n+3Trwft1JCDzyUNlX2J1fl7fwTgRPWtmBmiF6xIyueL5YGs65g==",
       "dev": true,
       "requires": {
-        "@oclif/command": "1.6.1",
-        "@oclif/errors": "1.2.2",
-        "@oclif/linewrap": "1.0.0",
-        "@oclif/screen": "1.0.4",
-        "ansi-escapes": "4.3.1",
-        "ansi-styles": "4.2.1",
-        "cardinal": "2.1.1",
-        "chalk": "2.4.2",
-        "clean-stack": "2.2.0",
-        "cli-progress": "3.8.2",
-        "extract-stack": "1.0.0",
-        "fs-extra": "7.0.1",
-        "hyperlinker": "1.0.0",
-        "indent-string": "4.0.0",
-        "is-wsl": "1.1.0",
-        "js-yaml": "3.14.0",
-        "lodash": "4.17.15",
-        "natural-orderby": "2.0.3",
-        "object-treeify": "1.1.25",
-        "password-prompt": "1.1.2",
-        "semver": "5.7.1",
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0",
-        "supports-color": "5.5.0",
-        "supports-hyperlinks": "1.0.1",
-        "tslib": "1.13.0"
+        "@oclif/command": "^1.6.0",
+        "@oclif/errors": "^1.2.1",
+        "@oclif/linewrap": "^1.0.0",
+        "@oclif/screen": "^1.0.3",
+        "ansi-escapes": "^4.3.0",
+        "ansi-styles": "^4.2.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^2.4.1",
+        "clean-stack": "^2.0.0",
+        "cli-progress": "^3.4.0",
+        "extract-stack": "^1.0.0",
+        "fs-extra": "^7.0.1",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^1.1.0",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.11",
+        "natural-orderby": "^2.0.1",
+        "object-treeify": "^1.1.4",
+        "password-prompt": "^1.1.2",
+        "semver": "^5.6.0",
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.1.0",
+        "supports-color": "^5.5.0",
+        "supports-hyperlinks": "^1.0.1",
+        "tslib": "^1.9.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5198,8 +5198,8 @@
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "@types/color-name": "1.1.1",
-            "color-convert": "2.0.1"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "color-convert": {
@@ -5208,7 +5208,7 @@
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.4"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
@@ -5235,9 +5235,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -5246,7 +5246,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -5263,9 +5263,9 @@
       "integrity": "sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==",
       "dev": true,
       "requires": {
-        "arch": "2.1.2",
-        "execa": "1.0.0",
-        "is-wsl": "2.2.0"
+        "arch": "^2.1.1",
+        "execa": "^1.0.0",
+        "is-wsl": "^2.1.1"
       },
       "dependencies": {
         "is-wsl": {
@@ -5274,7 +5274,7 @@
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
           "dev": true,
           "requires": {
-            "is-docker": "2.0.0"
+            "is-docker": "^2.0.0"
           }
         }
       }
@@ -5285,9 +5285,9 @@
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
       "requires": {
-        "string-width": "4.2.0",
-        "strip-ansi": "6.0.0",
-        "wrap-ansi": "6.2.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       }
     },
     "clone": {
@@ -5302,9 +5302,9 @@
       "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
       "dev": true,
       "requires": {
-        "@types/q": "1.5.4",
-        "chalk": "2.4.2",
-        "q": "1.5.1"
+        "@types/q": "^1.5.1",
+        "chalk": "^2.4.1",
+        "q": "^1.1.2"
       }
     },
     "code-point-at": {
@@ -5319,8 +5319,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color": {
@@ -5329,8 +5329,8 @@
       "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3",
-        "color-string": "1.5.3"
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
       }
     },
     "color-convert": {
@@ -5352,8 +5352,8 @@
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3",
-        "simple-swizzle": "0.2.2"
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "colors": {
@@ -5367,7 +5367,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -5412,7 +5412,7 @@
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": ">= 1.43.0 < 2"
       }
     },
     "compression": {
@@ -5421,13 +5421,13 @@
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.5",
         "bytes": "3.0.0",
-        "compressible": "2.0.18",
+        "compressible": "~2.0.16",
         "debug": "2.6.9",
-        "on-headers": "1.0.2",
+        "on-headers": "~1.0.2",
         "safe-buffer": "5.1.2",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "bytes": {
@@ -5465,10 +5465,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.7",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "configstore": {
@@ -5477,12 +5477,12 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.2.4",
-        "make-dir": "1.3.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.4.3",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       },
       "dependencies": {
         "dot-prop": {
@@ -5491,7 +5491,7 @@
           "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "dev": true,
           "requires": {
-            "is-obj": "1.0.1"
+            "is-obj": "^1.0.0"
           }
         },
         "is-obj": {
@@ -5506,7 +5506,7 @@
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -5540,7 +5540,7 @@
       "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
       "dev": true,
       "requires": {
-        "bluebird": "3.7.2"
+        "bluebird": "^3.1.1"
       }
     },
     "constant-case": {
@@ -5549,8 +5549,8 @@
       "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
       "dev": true,
       "requires": {
-        "snake-case": "2.1.0",
-        "upper-case": "1.1.3"
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
       }
     },
     "constants-browserify": {
@@ -5580,7 +5580,7 @@
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.1"
       }
     },
     "cookie": {
@@ -5606,12 +5606,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.5",
-        "rimraf": "2.7.1",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       }
     },
     "copy-descriptor": {
@@ -5626,18 +5626,18 @@
       "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
       "dev": true,
       "requires": {
-        "cacache": "12.0.4",
-        "find-cache-dir": "2.1.0",
-        "glob-parent": "3.1.0",
-        "globby": "7.1.1",
-        "is-glob": "4.0.1",
-        "loader-utils": "1.4.0",
-        "minimatch": "3.0.4",
-        "normalize-path": "3.0.0",
-        "p-limit": "2.3.0",
-        "schema-utils": "1.0.0",
-        "serialize-javascript": "2.1.2",
-        "webpack-log": "2.0.0"
+        "cacache": "^12.0.3",
+        "find-cache-dir": "^2.1.0",
+        "glob-parent": "^3.1.0",
+        "globby": "^7.1.1",
+        "is-glob": "^4.0.1",
+        "loader-utils": "^1.2.3",
+        "minimatch": "^3.0.4",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^2.1.2",
+        "webpack-log": "^2.0.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -5646,8 +5646,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -5656,7 +5656,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -5667,12 +5667,12 @@
           "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "dir-glob": "2.2.2",
-            "glob": "7.1.6",
-            "ignore": "3.3.10",
-            "pify": "3.0.0",
-            "slash": "1.0.0"
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
           }
         },
         "ignore": {
@@ -5687,7 +5687,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-try": {
@@ -5708,9 +5708,9 @@
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
-            "ajv": "6.12.2",
-            "ajv-errors": "1.0.1",
-            "ajv-keywords": "3.4.1"
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
           }
         },
         "slash": {
@@ -5732,7 +5732,7 @@
       "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
       "dev": true,
       "requires": {
-        "browserslist": "4.12.0",
+        "browserslist": "^4.8.5",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -5755,8 +5755,8 @@
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "vary": "1.1.2"
+        "object-assign": "^4",
+        "vary": "^1"
       }
     },
     "cosmiconfig": {
@@ -5765,10 +5765,10 @@
       "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "dev": true,
       "requires": {
-        "import-fresh": "2.0.0",
-        "is-directory": "0.3.1",
-        "js-yaml": "3.14.0",
-        "parse-json": "4.0.0"
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
       },
       "dependencies": {
         "parse-json": {
@@ -5777,8 +5777,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         }
       }
@@ -5789,8 +5789,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.9",
-        "elliptic": "6.5.2"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       },
       "dependencies": {
         "bn.js": {
@@ -5807,7 +5807,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "1.0.1"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "create-hash": {
@@ -5816,11 +5816,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.4",
-        "md5.js": "1.3.5",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -5829,12 +5829,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.4",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-fetch": {
@@ -5861,11 +5861,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.5",
-        "path-key": "2.0.1",
-        "semver": "5.7.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-browserify": {
@@ -5874,17 +5874,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.2.0",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.4",
-        "pbkdf2": "3.0.17",
-        "public-encrypt": "4.0.3",
-        "randombytes": "2.1.0",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "crypto-js": {
@@ -5910,8 +5910,8 @@
       "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31",
-        "timsort": "0.3.0"
+        "postcss": "^7.0.1",
+        "timsort": "^0.3.0"
       }
     },
     "css-loader": {
@@ -5920,19 +5920,19 @@
       "integrity": "sha512-UEr9NH5Lmi7+dguAm+/JSPovNjYbm2k3TK58EiwQHzOHH5Jfq1Y+XoP2bQO6TMn7PptMd0opxxedAWcaSTRKHw==",
       "dev": true,
       "requires": {
-        "camelcase": "5.3.1",
-        "cssesc": "3.0.0",
-        "icss-utils": "4.1.1",
-        "loader-utils": "1.4.0",
-        "normalize-path": "3.0.0",
-        "postcss": "7.0.31",
-        "postcss-modules-extract-imports": "2.0.0",
-        "postcss-modules-local-by-default": "3.0.2",
-        "postcss-modules-scope": "2.2.0",
-        "postcss-modules-values": "3.0.0",
-        "postcss-value-parser": "4.1.0",
-        "schema-utils": "2.7.0",
-        "semver": "6.3.0"
+        "camelcase": "^5.3.1",
+        "cssesc": "^3.0.0",
+        "icss-utils": "^4.1.1",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.27",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-scope": "^2.2.0",
+        "postcss-modules-values": "^3.0.0",
+        "postcss-value-parser": "^4.0.3",
+        "schema-utils": "^2.6.6",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -5949,10 +5949,10 @@
       "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "3.2.1",
-        "domutils": "1.7.0",
-        "nth-check": "1.0.2"
+        "boolbase": "^1.0.0",
+        "css-what": "^3.2.1",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
       }
     },
     "css-select-base-adapter": {
@@ -5968,7 +5968,7 @@
       "dev": true,
       "requires": {
         "mdn-data": "2.0.4",
-        "source-map": "0.6.1"
+        "source-map": "^0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -5997,10 +5997,10 @@
       "integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "5.2.1",
-        "cssnano-preset-default": "4.0.7",
-        "is-resolvable": "1.1.0",
-        "postcss": "7.0.31"
+        "cosmiconfig": "^5.0.0",
+        "cssnano-preset-default": "^4.0.7",
+        "is-resolvable": "^1.0.0",
+        "postcss": "^7.0.0"
       }
     },
     "cssnano-preset-default": {
@@ -6009,36 +6009,36 @@
       "integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
       "dev": true,
       "requires": {
-        "css-declaration-sorter": "4.0.1",
-        "cssnano-util-raw-cache": "4.0.1",
-        "postcss": "7.0.31",
-        "postcss-calc": "7.0.2",
-        "postcss-colormin": "4.0.3",
-        "postcss-convert-values": "4.0.1",
-        "postcss-discard-comments": "4.0.2",
-        "postcss-discard-duplicates": "4.0.2",
-        "postcss-discard-empty": "4.0.1",
-        "postcss-discard-overridden": "4.0.1",
-        "postcss-merge-longhand": "4.0.11",
-        "postcss-merge-rules": "4.0.3",
-        "postcss-minify-font-values": "4.0.2",
-        "postcss-minify-gradients": "4.0.2",
-        "postcss-minify-params": "4.0.2",
-        "postcss-minify-selectors": "4.0.2",
-        "postcss-normalize-charset": "4.0.1",
-        "postcss-normalize-display-values": "4.0.2",
-        "postcss-normalize-positions": "4.0.2",
-        "postcss-normalize-repeat-style": "4.0.2",
-        "postcss-normalize-string": "4.0.2",
-        "postcss-normalize-timing-functions": "4.0.2",
-        "postcss-normalize-unicode": "4.0.1",
-        "postcss-normalize-url": "4.0.1",
-        "postcss-normalize-whitespace": "4.0.2",
-        "postcss-ordered-values": "4.1.2",
-        "postcss-reduce-initial": "4.0.3",
-        "postcss-reduce-transforms": "4.0.2",
-        "postcss-svgo": "4.0.2",
-        "postcss-unique-selectors": "4.0.1"
+        "css-declaration-sorter": "^4.0.1",
+        "cssnano-util-raw-cache": "^4.0.1",
+        "postcss": "^7.0.0",
+        "postcss-calc": "^7.0.1",
+        "postcss-colormin": "^4.0.3",
+        "postcss-convert-values": "^4.0.1",
+        "postcss-discard-comments": "^4.0.2",
+        "postcss-discard-duplicates": "^4.0.2",
+        "postcss-discard-empty": "^4.0.1",
+        "postcss-discard-overridden": "^4.0.1",
+        "postcss-merge-longhand": "^4.0.11",
+        "postcss-merge-rules": "^4.0.3",
+        "postcss-minify-font-values": "^4.0.2",
+        "postcss-minify-gradients": "^4.0.2",
+        "postcss-minify-params": "^4.0.2",
+        "postcss-minify-selectors": "^4.0.2",
+        "postcss-normalize-charset": "^4.0.1",
+        "postcss-normalize-display-values": "^4.0.2",
+        "postcss-normalize-positions": "^4.0.2",
+        "postcss-normalize-repeat-style": "^4.0.2",
+        "postcss-normalize-string": "^4.0.2",
+        "postcss-normalize-timing-functions": "^4.0.2",
+        "postcss-normalize-unicode": "^4.0.1",
+        "postcss-normalize-url": "^4.0.1",
+        "postcss-normalize-whitespace": "^4.0.2",
+        "postcss-ordered-values": "^4.1.2",
+        "postcss-reduce-initial": "^4.0.3",
+        "postcss-reduce-transforms": "^4.0.2",
+        "postcss-svgo": "^4.0.2",
+        "postcss-unique-selectors": "^4.0.1"
       }
     },
     "cssnano-util-get-arguments": {
@@ -6059,7 +6059,7 @@
       "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31"
+        "postcss": "^7.0.0"
       }
     },
     "cssnano-util-same-parent": {
@@ -6084,7 +6084,7 @@
           "dev": true,
           "requires": {
             "mdn-data": "2.0.6",
-            "source-map": "0.6.1"
+            "source-map": "^0.6.1"
           }
         },
         "mdn-data": {
@@ -6113,7 +6113,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-fns": {
@@ -6134,7 +6134,7 @@
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -6155,12 +6155,12 @@
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
       "dev": true,
       "requires": {
-        "is-arguments": "1.0.4",
-        "is-date-object": "1.0.2",
-        "is-regex": "1.0.5",
-        "object-is": "1.1.2",
-        "object-keys": "1.1.1",
-        "regexp.prototype.flags": "1.3.0"
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
       }
     },
     "deep-extend": {
@@ -6187,7 +6187,7 @@
       "integrity": "sha512-z2RnruVmj8hVMmAnEJMTIJNijhKCDiGjbLP+BHJFOT7ld3Bo5qcIBpVYDniqhbMIIf+jZDlkP2MkPXiQy/DBLA==",
       "dev": true,
       "requires": {
-        "execa": "3.4.0"
+        "execa": "^3.3.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -6196,9 +6196,9 @@
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.1",
-            "shebang-command": "2.0.0",
-            "which": "2.0.2"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "execa": {
@@ -6207,16 +6207,16 @@
           "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
           "dev": true,
           "requires": {
-            "cross-spawn": "7.0.3",
-            "get-stream": "5.1.0",
-            "human-signals": "1.1.1",
-            "is-stream": "2.0.0",
-            "merge-stream": "2.0.0",
-            "npm-run-path": "4.0.1",
-            "onetime": "5.1.0",
-            "p-finally": "2.0.1",
-            "signal-exit": "3.0.3",
-            "strip-final-newline": "2.0.0"
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
         },
         "get-stream": {
@@ -6225,7 +6225,7 @@
           "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "is-stream": {
@@ -6246,7 +6246,7 @@
           "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.1"
+            "path-key": "^3.0.0"
           }
         },
         "onetime": {
@@ -6255,7 +6255,7 @@
           "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
           "dev": true,
           "requires": {
-            "mimic-fn": "2.1.0"
+            "mimic-fn": "^2.1.0"
           }
         },
         "p-finally": {
@@ -6276,7 +6276,7 @@
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
-            "shebang-regex": "3.0.0"
+            "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
@@ -6291,7 +6291,7 @@
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -6302,7 +6302,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.4"
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -6311,7 +6311,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "define-property": {
@@ -6320,8 +6320,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -6330,7 +6330,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -6339,7 +6339,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -6348,9 +6348,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.3"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -6361,13 +6361,13 @@
       "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
       "dev": true,
       "requires": {
-        "@types/glob": "7.1.1",
-        "globby": "6.1.0",
-        "is-path-cwd": "2.2.0",
-        "is-path-in-cwd": "2.1.0",
-        "p-map": "2.1.0",
-        "pify": "4.0.1",
-        "rimraf": "2.7.1"
+        "@types/glob": "^7.1.1",
+        "globby": "^6.1.0",
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
+        "pify": "^4.0.1",
+        "rimraf": "^2.6.3"
       },
       "dependencies": {
         "globby": {
@@ -6376,11 +6376,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.6",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -6422,8 +6422,8 @@
       "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -6459,9 +6459,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.9",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.1.0"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       },
       "dependencies": {
         "bn.js": {
@@ -6478,7 +6478,7 @@
       "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
       "dev": true,
       "requires": {
-        "path-type": "3.0.0"
+        "path-type": "^3.0.0"
       }
     },
     "dns-equal": {
@@ -6493,8 +6493,8 @@
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "dev": true,
       "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.2"
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "dns-txt": {
@@ -6503,7 +6503,7 @@
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
-        "buffer-indexof": "1.1.1"
+        "buffer-indexof": "^1.0.0"
       }
     },
     "doctrine": {
@@ -6512,7 +6512,7 @@
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.3"
+        "esutils": "^2.0.2"
       }
     },
     "dom-align": {
@@ -6525,7 +6525,7 @@
       "resolved": "https://registry.npmjs.org/dom-closest/-/dom-closest-0.2.0.tgz",
       "integrity": "sha1-69n5HRvyLo1vR3h2u80+yQIWwM8=",
       "requires": {
-        "dom-matches": "2.0.0"
+        "dom-matches": ">=1.0.1"
       }
     },
     "dom-converter": {
@@ -6534,7 +6534,7 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dev": true,
       "requires": {
-        "utila": "0.4.0"
+        "utila": "~0.4"
       }
     },
     "dom-matches": {
@@ -6553,8 +6553,8 @@
       "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
       "dev": true,
       "requires": {
-        "domelementtype": "2.0.1",
-        "entities": "2.0.2"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
       },
       "dependencies": {
         "domelementtype": {
@@ -6583,7 +6583,7 @@
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.1"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -6592,8 +6592,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.2.2",
-        "domelementtype": "1.3.1"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-case": {
@@ -6602,7 +6602,7 @@
       "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "dot-prop": {
@@ -6611,7 +6611,7 @@
       "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
       "dev": true,
       "requires": {
-        "is-obj": "2.0.0"
+        "is-obj": "^2.0.0"
       }
     },
     "dotenv": {
@@ -6644,10 +6644,10 @@
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.4",
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.7",
-        "stream-shift": "1.0.1"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "easy-stack": {
@@ -6662,8 +6662,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -6696,13 +6696,13 @@
       "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.9",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.7",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.4",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       },
       "dependencies": {
         "bn.js": {
@@ -6737,7 +6737,7 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -6746,9 +6746,9 @@
       "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "memory-fs": "0.5.0",
-        "tapable": "1.1.3"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.5.0",
+        "tapable": "^1.0.0"
       },
       "dependencies": {
         "memory-fs": {
@@ -6757,8 +6757,8 @@
           "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
           "dev": true,
           "requires": {
-            "errno": "0.1.7",
-            "readable-stream": "2.3.7"
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
           }
         }
       }
@@ -6780,8 +6780,8 @@
       "integrity": "sha512-AOiNZ3lmxrtva3r/roqaYDF+1PX2V+ouUzuGqJf7KNxyyYkuU+CsfFbbUeibQPdixxjI/lP6eDtvtkX1/wymJw==",
       "dev": true,
       "requires": {
-        "execa": "1.0.0",
-        "java-properties": "1.0.2"
+        "execa": "^1.0.0",
+        "java-properties": "^1.0.0"
       }
     },
     "errno": {
@@ -6790,7 +6790,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -6799,7 +6799,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "error-stack-parser": {
@@ -6808,7 +6808,7 @@
       "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
       "dev": true,
       "requires": {
-        "stackframe": "1.1.1"
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -6817,17 +6817,17 @@
       "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.2.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "has-symbols": "1.0.1",
-        "is-callable": "1.1.5",
-        "is-regex": "1.0.5",
-        "object-inspect": "1.7.0",
-        "object-keys": "1.1.1",
-        "object.assign": "4.1.0",
-        "string.prototype.trimleft": "2.1.2",
-        "string.prototype.trimright": "2.1.2"
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
@@ -6836,9 +6836,9 @@
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.5",
-        "is-date-object": "1.0.2",
-        "is-symbol": "1.0.3"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-promise": {
@@ -6863,43 +6863,43 @@
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.10.1",
-        "ajv": "6.12.2",
-        "chalk": "2.4.2",
-        "cross-spawn": "6.0.5",
-        "debug": "4.1.1",
-        "doctrine": "3.0.0",
-        "eslint-scope": "5.1.0",
-        "eslint-utils": "1.4.3",
-        "eslint-visitor-keys": "1.1.0",
-        "espree": "6.2.1",
-        "esquery": "1.3.1",
-        "esutils": "2.0.3",
-        "file-entry-cache": "5.0.1",
-        "functional-red-black-tree": "1.0.1",
-        "glob-parent": "5.1.1",
-        "globals": "12.4.0",
-        "ignore": "4.0.6",
-        "import-fresh": "3.2.1",
-        "imurmurhash": "0.1.4",
-        "inquirer": "7.1.0",
-        "is-glob": "4.0.1",
-        "js-yaml": "3.14.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.5",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.3",
-        "progress": "2.0.3",
-        "regexpp": "2.0.1",
-        "semver": "6.3.0",
-        "strip-ansi": "5.2.0",
-        "strip-json-comments": "3.1.0",
-        "table": "5.4.6",
-        "text-table": "0.2.0",
-        "v8-compile-cache": "2.1.1"
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "eslint-scope": {
@@ -6908,8 +6908,8 @@
           "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
           "dev": true,
           "requires": {
-            "esrecurse": "4.2.1",
-            "estraverse": "4.3.0"
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         },
         "globals": {
@@ -6918,7 +6918,7 @@
           "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
           "dev": true,
           "requires": {
-            "type-fest": "0.8.1"
+            "type-fest": "^0.8.1"
           }
         },
         "import-fresh": {
@@ -6927,8 +6927,8 @@
           "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
           "dev": true,
           "requires": {
-            "parent-module": "1.0.1",
-            "resolve-from": "4.0.0"
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
           }
         },
         "resolve-from": {
@@ -6949,7 +6949,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "type-fest": {
@@ -6966,7 +6966,7 @@
       "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
       "dev": true,
       "requires": {
-        "get-stdin": "6.0.0"
+        "get-stdin": "^6.0.0"
       }
     },
     "eslint-loader": {
@@ -6975,11 +6975,11 @@
       "integrity": "sha512-RLgV9hoCVsMLvOxCuNjdqOrUqIj9oJg8hF44vzJaYqsAHuY9G2YAeN3joQ9nxP0p5Th9iFSIpKo+SD8KISxXRg==",
       "dev": true,
       "requires": {
-        "loader-fs-cache": "1.0.3",
-        "loader-utils": "1.4.0",
-        "object-assign": "4.1.1",
-        "object-hash": "1.3.1",
-        "rimraf": "2.7.1"
+        "loader-fs-cache": "^1.0.0",
+        "loader-utils": "^1.0.2",
+        "object-assign": "^4.0.1",
+        "object-hash": "^1.1.4",
+        "rimraf": "^2.6.1"
       }
     },
     "eslint-plugin-graphql": {
@@ -6988,8 +6988,8 @@
       "integrity": "sha512-JT2paUyu3e9ZDnroSshwUMc6pKcnkfXTsZInX1+/rPotvqOLVLtdrx/cmfb7PTJwjiEAshwcpm3/XPdTpsKJPw==",
       "dev": true,
       "requires": {
-        "graphql-config": "2.2.2",
-        "lodash": "4.17.15"
+        "graphql-config": "^2.0.1",
+        "lodash": "^4.11.1"
       }
     },
     "eslint-plugin-prettier": {
@@ -6998,7 +6998,7 @@
       "integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
       "dev": true,
       "requires": {
-        "prettier-linter-helpers": "1.0.0"
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-vue": {
@@ -7007,10 +7007,10 @@
       "integrity": "sha512-ODTeB/Vr8CUutkS5u55v3Q6RvCd3nHIkk+GpuklRjtlcoopm2DOIQ1rgZLi0Otlh+a0iyGkMW4dlvj7weEEk2w==",
       "dev": true,
       "requires": {
-        "eslint-utils": "2.0.0",
-        "natural-compare": "1.4.0",
-        "semver": "7.3.2",
-        "vue-eslint-parser": "7.1.0"
+        "eslint-utils": "^2.0.0",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.3.2",
+        "vue-eslint-parser": "^7.1.0"
       },
       "dependencies": {
         "eslint-utils": {
@@ -7019,7 +7019,7 @@
           "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
           "dev": true,
           "requires": {
-            "eslint-visitor-keys": "1.1.0"
+            "eslint-visitor-keys": "^1.1.0"
           }
         },
         "semver": {
@@ -7036,8 +7036,8 @@
       "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.3.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -7046,7 +7046,7 @@
       "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "1.1.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -7067,9 +7067,9 @@
       "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "7.2.0",
-        "acorn-jsx": "5.2.0",
-        "eslint-visitor-keys": "1.1.0"
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
       },
       "dependencies": {
         "acorn": {
@@ -7092,7 +7092,7 @@
       "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
-        "estraverse": "5.1.0"
+        "estraverse": "^5.1.0"
       },
       "dependencies": {
         "estraverse": {
@@ -7109,7 +7109,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.3.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -7154,7 +7154,7 @@
       "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
       "dev": true,
       "requires": {
-        "original": "1.0.2"
+        "original": "^1.0.0"
       }
     },
     "evp_bytestokey": {
@@ -7163,8 +7163,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.5",
-        "safe-buffer": "5.1.2"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "execa": {
@@ -7173,13 +7173,13 @@
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "6.0.5",
-        "get-stream": "4.1.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.3",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -7188,13 +7188,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -7212,7 +7212,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -7221,7 +7221,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "ms": {
@@ -7238,36 +7238,36 @@
       "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
         "body-parser": "1.19.0",
         "content-disposition": "0.5.3",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "finalhandler": "1.1.2",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.6",
+        "proxy-addr": "~2.0.5",
         "qs": "6.7.0",
-        "range-parser": "1.2.1",
+        "range-parser": "~1.2.1",
         "safe-buffer": "5.1.2",
         "send": "0.17.1",
         "serve-static": "1.14.1",
         "setprototypeof": "1.1.1",
-        "statuses": "1.5.0",
-        "type-is": "1.6.18",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -7304,8 +7304,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -7314,7 +7314,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -7325,9 +7325,9 @@
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
-        "chardet": "0.7.0",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -7336,14 +7336,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -7352,7 +7352,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -7361,7 +7361,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -7370,7 +7370,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -7379,7 +7379,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -7388,9 +7388,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.3"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -7431,12 +7431,12 @@
       "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "2.2.1",
-        "@nodelib/fs.stat": "1.1.3",
-        "glob-parent": "3.1.0",
-        "is-glob": "4.0.1",
-        "merge2": "1.3.0",
-        "micromatch": "3.1.10"
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
       },
       "dependencies": {
         "glob-parent": {
@@ -7445,8 +7445,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -7455,7 +7455,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -7479,7 +7479,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.6.5"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "figgy-pudding": {
@@ -7494,7 +7494,7 @@
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -7503,7 +7503,7 @@
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "2.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "file-loader": {
@@ -7512,8 +7512,8 @@
       "integrity": "sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.4.0",
-        "schema-utils": "2.7.0"
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.5.0"
       }
     },
     "file-uri-to-path": {
@@ -7535,10 +7535,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -7547,7 +7547,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7559,12 +7559,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
-        "statuses": "1.5.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -7590,9 +7590,9 @@
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "2.1.0",
-        "pkg-dir": "3.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
       }
     },
     "find-up": {
@@ -7601,7 +7601,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -7610,7 +7610,7 @@
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "flatted": "2.0.2",
+        "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
       },
@@ -7621,7 +7621,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "7.1.6"
+            "glob": "^7.1.3"
           }
         }
       }
@@ -7638,8 +7638,8 @@
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.7"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
       }
     },
     "follow-redirects": {
@@ -7648,7 +7648,7 @@
       "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
       "dev": true,
       "requires": {
-        "debug": "3.2.6"
+        "debug": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -7657,7 +7657,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -7679,9 +7679,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.8",
-        "mime-types": "2.1.27"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "formidable": {
@@ -7701,7 +7701,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -7716,8 +7716,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.7"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-capacitor": {
@@ -7732,9 +7732,9 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-minipass": {
@@ -7743,7 +7743,7 @@
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "dev": true,
       "requires": {
-        "minipass": "3.1.3"
+        "minipass": "^3.0.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -7752,10 +7752,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.7"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -7789,7 +7789,7 @@
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
-        "globule": "1.3.1"
+        "globule": "^1.0.0"
       }
     },
     "gensync": {
@@ -7816,7 +7816,7 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "requires": {
-        "pump": "3.0.0"
+        "pump": "^3.0.0"
       }
     },
     "get-value": {
@@ -7831,7 +7831,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "git-parse": {
@@ -7869,12 +7869,12 @@
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.4",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -7883,7 +7883,7 @@
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
-        "is-glob": "4.0.1"
+        "is-glob": "^4.0.1"
       }
     },
     "glob-to-regexp": {
@@ -7898,7 +7898,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.4"
       }
     },
     "globals": {
@@ -7913,14 +7913,14 @@
       "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
       "dev": true,
       "requires": {
-        "@types/glob": "7.1.1",
-        "array-union": "1.0.2",
-        "dir-glob": "2.2.2",
-        "fast-glob": "2.2.7",
-        "glob": "7.1.6",
-        "ignore": "4.0.6",
-        "pify": "4.0.1",
-        "slash": "2.0.0"
+        "@types/glob": "^7.1.1",
+        "array-union": "^1.0.2",
+        "dir-glob": "^2.2.2",
+        "fast-glob": "^2.2.6",
+        "glob": "^7.1.3",
+        "ignore": "^4.0.3",
+        "pify": "^4.0.1",
+        "slash": "^2.0.0"
       }
     },
     "globule": {
@@ -7929,9 +7929,9 @@
       "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
       "dev": true,
       "requires": {
-        "glob": "7.1.6",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.12",
+        "minimatch": "~3.0.2"
       }
     },
     "got": {
@@ -7940,17 +7940,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.2.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.1",
-        "safe-buffer": "5.1.2",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       },
       "dependencies": {
         "get-stream": {
@@ -7977,9 +7977,9 @@
       "integrity": "sha512-fJHvVywWVWjiHuPIMs16Nfjf4zdQUwSO1LKycwBJCWIPeoeQ8LqXK2BgYoZAHkhKEFktZZeYyzS4o/uIUG0z5A==",
       "dev": true,
       "requires": {
-        "apollo-utilities": "1.3.4",
-        "ts-invariant": "0.3.3",
-        "tslib": "1.13.0"
+        "apollo-utilities": "^1.3.4",
+        "ts-invariant": "^0.3.2",
+        "tslib": "^1.10.0"
       },
       "dependencies": {
         "ts-invariant": {
@@ -7988,7 +7988,7 @@
           "integrity": "sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==",
           "dev": true,
           "requires": {
-            "tslib": "1.13.0"
+            "tslib": "^1.9.3"
           }
         }
       }
@@ -7999,11 +7999,11 @@
       "integrity": "sha512-mtv1ejPyyR2mJUUZNhljggU+B/Xl8tJJWf+h145hB+1Y48acSghFalhNtXfPBcYl2tJzpb+lGxfj3O7OjaiMgw==",
       "dev": true,
       "requires": {
-        "graphql-import": "0.7.1",
-        "graphql-request": "1.8.2",
-        "js-yaml": "3.14.0",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4"
+        "graphql-import": "^0.7.1",
+        "graphql-request": "^1.5.0",
+        "js-yaml": "^3.10.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4"
       }
     },
     "graphql-extensions": {
@@ -8012,9 +8012,9 @@
       "integrity": "sha512-vFaZua5aLiCOOzxfY5qzHZ6S52BCqW7VVOwzvV52Wb5edRm3dn6u+1MR9yYyEqUHSf8LvdhEojYlOkKiaQ4ghA==",
       "dev": true,
       "requires": {
-        "@apollographql/apollo-tools": "0.4.8",
-        "apollo-server-env": "2.4.4",
-        "apollo-server-types": "0.5.0"
+        "@apollographql/apollo-tools": "^0.4.3",
+        "apollo-server-env": "^2.4.4",
+        "apollo-server-types": "^0.5.0"
       }
     },
     "graphql-import": {
@@ -8023,8 +8023,8 @@
       "integrity": "sha512-YpwpaPjRUVlw2SN3OPljpWbVRWAhMAyfSba5U47qGMOSsPLi2gYeJtngGpymjm9nk57RFWEpjqwh4+dpYuFAPw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.15",
-        "resolve-from": "4.0.0"
+        "lodash": "^4.17.4",
+        "resolve-from": "^4.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -8050,7 +8050,7 @@
       "integrity": "sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==",
       "dev": true,
       "requires": {
-        "iterall": "1.3.0"
+        "iterall": "^1.2.1"
       }
     },
     "graphql-tag": {
@@ -8064,11 +8064,11 @@
       "integrity": "sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==",
       "dev": true,
       "requires": {
-        "apollo-link": "1.2.14",
-        "apollo-utilities": "1.3.4",
-        "deprecated-decorator": "0.1.6",
-        "iterall": "1.3.0",
-        "uuid": "3.4.0"
+        "apollo-link": "^1.2.14",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
       }
     },
     "graphql-type-json": {
@@ -8082,10 +8082,10 @@
       "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
       "dev": true,
       "requires": {
-        "busboy": "0.3.1",
-        "fs-capacitor": "2.0.4",
-        "http-errors": "1.7.3",
-        "object-path": "0.11.4"
+        "busboy": "^0.3.1",
+        "fs-capacitor": "^2.0.4",
+        "http-errors": "^1.7.3",
+        "object-path": "^0.11.4"
       },
       "dependencies": {
         "http-errors": {
@@ -8094,10 +8094,10 @@
           "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
           "dev": true,
           "requires": {
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "inherits": "2.0.4",
             "setprototypeof": "1.1.1",
-            "statuses": "1.5.0",
+            "statuses": ">= 1.5.0 < 2",
             "toidentifier": "1.0.0"
           }
         }
@@ -8109,8 +8109,8 @@
       "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "pify": "4.0.1"
+        "duplexer": "^0.1.1",
+        "pify": "^4.0.1"
       }
     },
     "handle-thing": {
@@ -8131,8 +8131,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "6.12.2",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -8141,7 +8141,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -8150,7 +8150,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8178,9 +8178,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -8189,8 +8189,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -8199,7 +8199,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -8210,9 +8210,9 @@
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "3.6.0",
-        "safe-buffer": "5.2.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -8221,9 +8221,9 @@
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "safe-buffer": {
@@ -8246,8 +8246,8 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "he": {
@@ -8262,8 +8262,8 @@
       "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
       }
     },
     "hex-color-regex": {
@@ -8284,9 +8284,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.7",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoopy": {
@@ -8307,10 +8307,10 @@
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "obuf": "1.1.2",
-        "readable-stream": "2.3.7",
-        "wbuf": "1.7.3"
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
       }
     },
     "hsl-regex": {
@@ -8343,13 +8343,13 @@
       "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.0",
-        "clean-css": "4.2.3",
-        "commander": "2.17.1",
-        "he": "1.2.0",
-        "param-case": "2.1.1",
-        "relateurl": "0.2.7",
-        "uglify-js": "3.4.10"
+        "camel-case": "3.0.x",
+        "clean-css": "4.2.x",
+        "commander": "2.17.x",
+        "he": "1.2.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.4.x"
       },
       "dependencies": {
         "commander": {
@@ -8372,12 +8372,12 @@
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
-        "html-minifier": "3.5.21",
-        "loader-utils": "0.2.17",
-        "lodash": "4.17.15",
-        "pretty-error": "2.1.1",
-        "tapable": "1.1.3",
-        "toposort": "1.0.7",
+        "html-minifier": "^3.2.3",
+        "loader-utils": "^0.2.16",
+        "lodash": "^4.17.3",
+        "pretty-error": "^2.0.2",
+        "tapable": "^1.0.0",
+        "toposort": "^1.0.0",
         "util.promisify": "1.0.0"
       },
       "dependencies": {
@@ -8405,10 +8405,10 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         },
         "util.promisify": {
@@ -8417,8 +8417,8 @@
           "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
           "dev": true,
           "requires": {
-            "define-properties": "1.1.3",
-            "object.getownpropertydescriptors": "2.1.0"
+            "define-properties": "^1.1.2",
+            "object.getownpropertydescriptors": "^2.0.3"
           }
         }
       }
@@ -8429,12 +8429,12 @@
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.1",
-        "domhandler": "2.4.2",
-        "domutils": "1.7.0",
-        "entities": "1.1.2",
-        "inherits": "2.0.4",
-        "readable-stream": "3.6.0"
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "entities": {
@@ -8449,9 +8449,9 @@
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -8462,12 +8462,12 @@
       "integrity": "sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==",
       "dev": true,
       "requires": {
-        "content-type": "1.0.4",
-        "debug": "4.1.1",
-        "is-retry-allowed": "1.2.0",
-        "is-stream": "2.0.0",
-        "parse-json": "4.0.0",
-        "tunnel-agent": "0.6.0"
+        "content-type": "^1.0.4",
+        "debug": "^4.1.1",
+        "is-retry-allowed": "^1.1.0",
+        "is-stream": "^2.0.0",
+        "parse-json": "^4.0.0",
+        "tunnel-agent": "^0.6.0"
       },
       "dependencies": {
         "is-stream": {
@@ -8482,8 +8482,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         }
       }
@@ -8500,10 +8500,10 @@
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.1",
-        "statuses": "1.5.0",
+        "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       },
       "dependencies": {
@@ -8521,9 +8521,9 @@
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
       "requires": {
-        "eventemitter3": "4.0.4",
-        "follow-redirects": "1.11.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -8532,10 +8532,10 @@
       "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
       "dev": true,
       "requires": {
-        "http-proxy": "1.18.1",
-        "is-glob": "4.0.1",
-        "lodash": "4.17.15",
-        "micromatch": "3.1.10"
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
       }
     },
     "http-signature": {
@@ -8544,9 +8544,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.16.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -8573,7 +8573,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "icss-utils": {
@@ -8582,7 +8582,7 @@
       "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31"
+        "postcss": "^7.0.14"
       }
     },
     "idtoken-verifier": {
@@ -8590,12 +8590,12 @@
       "resolved": "https://registry.npmjs.org/idtoken-verifier/-/idtoken-verifier-2.0.3.tgz",
       "integrity": "sha512-X1izD2ZTMoo+2tw2RKVUvvCSw2B6UOCNMJ0bgHRH758LFTMwBf4JZfCZm61MPBaBW2CIuhkcSnKCZP6jXpSDmw==",
       "requires": {
-        "base64-js": "1.3.1",
-        "crypto-js": "3.3.0",
-        "es6-promise": "4.2.8",
-        "jsbn": "1.1.0",
-        "unfetch": "4.1.0",
-        "url-join": "4.0.1"
+        "base64-js": "^1.3.0",
+        "crypto-js": "^3.2.1",
+        "es6-promise": "^4.2.8",
+        "jsbn": "^1.1.0",
+        "unfetch": "^4.1.0",
+        "url-join": "^4.0.1"
       },
       "dependencies": {
         "jsbn": {
@@ -8635,7 +8635,7 @@
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
-        "import-from": "2.1.0"
+        "import-from": "^2.1.0"
       }
     },
     "import-fresh": {
@@ -8644,8 +8644,8 @@
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
-        "caller-path": "2.0.0",
-        "resolve-from": "3.0.0"
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
       }
     },
     "import-from": {
@@ -8654,7 +8654,7 @@
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "import-lazy": {
@@ -8669,8 +8669,8 @@
       "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "3.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -8709,8 +8709,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -8730,19 +8730,19 @@
       "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "4.3.1",
-        "chalk": "3.0.0",
-        "cli-cursor": "3.1.0",
-        "cli-width": "2.2.1",
-        "external-editor": "3.1.0",
-        "figures": "3.2.0",
-        "lodash": "4.17.15",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
-        "run-async": "2.4.1",
-        "rxjs": "6.5.5",
-        "string-width": "4.2.0",
-        "strip-ansi": "6.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8751,8 +8751,8 @@
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "@types/color-name": "1.1.1",
-            "color-convert": "2.0.1"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "chalk": {
@@ -8761,8 +8761,8 @@
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
-            "ansi-styles": "4.2.1",
-            "supports-color": "7.1.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
         "cli-cursor": {
@@ -8771,7 +8771,7 @@
           "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
           "dev": true,
           "requires": {
-            "restore-cursor": "3.1.0"
+            "restore-cursor": "^3.1.0"
           }
         },
         "color-convert": {
@@ -8780,7 +8780,7 @@
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.4"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
@@ -8807,7 +8807,7 @@
           "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
           "dev": true,
           "requires": {
-            "mimic-fn": "2.1.0"
+            "mimic-fn": "^2.1.0"
           }
         },
         "restore-cursor": {
@@ -8816,8 +8816,8 @@
           "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
           "dev": true,
           "requires": {
-            "onetime": "5.1.0",
-            "signal-exit": "3.0.3"
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "supports-color": {
@@ -8826,7 +8826,7 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "4.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -8837,8 +8837,8 @@
       "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
       "dev": true,
       "requires": {
-        "default-gateway": "4.2.0",
-        "ipaddr.js": "1.9.1"
+        "default-gateway": "^4.2.0",
+        "ipaddr.js": "^1.9.0"
       },
       "dependencies": {
         "default-gateway": {
@@ -8847,8 +8847,8 @@
           "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
           "dev": true,
           "requires": {
-            "execa": "1.0.0",
-            "ip-regex": "2.1.0"
+            "execa": "^1.0.0",
+            "ip-regex": "^2.1.0"
           }
         }
       }
@@ -8870,7 +8870,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "ip": {
@@ -8903,7 +8903,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8912,7 +8912,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -8936,7 +8936,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "binary-extensions": "2.0.0"
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-buffer": {
@@ -8957,7 +8957,7 @@
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.6.0"
+        "ci-info": "^1.5.0"
       }
     },
     "is-color-stop": {
@@ -8966,12 +8966,12 @@
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "dev": true,
       "requires": {
-        "css-color-names": "0.0.4",
-        "hex-color-regex": "1.1.0",
-        "hsl-regex": "1.0.0",
-        "hsla-regex": "1.0.0",
-        "rgb-regex": "1.0.1",
-        "rgba-regex": "1.0.0"
+        "css-color-names": "^0.0.4",
+        "hex-color-regex": "^1.1.0",
+        "hsl-regex": "^1.0.0",
+        "hsla-regex": "^1.0.0",
+        "rgb-regex": "^1.0.1",
+        "rgba-regex": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -8980,7 +8980,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8989,7 +8989,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -9006,9 +9006,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -9055,7 +9055,7 @@
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-installed-globally": {
@@ -9064,8 +9064,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       },
       "dependencies": {
         "is-path-inside": {
@@ -9074,7 +9074,7 @@
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
-            "path-is-inside": "1.0.2"
+            "path-is-inside": "^1.0.1"
           }
         }
       }
@@ -9085,7 +9085,7 @@
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.0"
       }
     },
     "is-mobile": {
@@ -9110,7 +9110,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -9119,7 +9119,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -9136,7 +9136,7 @@
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.2.0"
+        "symbol-observable": "^1.1.0"
       }
     },
     "is-path-cwd": {
@@ -9151,7 +9151,7 @@
       "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "2.1.0"
+        "is-path-inside": "^2.1.0"
       }
     },
     "is-path-inside": {
@@ -9160,7 +9160,7 @@
       "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.2"
       }
     },
     "is-plain-obj": {
@@ -9175,7 +9175,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
@@ -9195,7 +9195,7 @@
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.3"
       }
     },
     "is-resolvable": {
@@ -9222,7 +9222,7 @@
       "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
       "dev": true,
       "requires": {
-        "html-comment-regex": "1.1.2"
+        "html-comment-regex": "^1.1.0"
       }
     },
     "is-symbol": {
@@ -9231,7 +9231,7 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.1"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -9246,7 +9246,7 @@
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "dev": true,
       "requires": {
-        "upper-case": "1.1.3"
+        "upper-case": "^1.1.0"
       }
     },
     "is-windows": {
@@ -9313,8 +9313,8 @@
       "integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
       "dev": true,
       "requires": {
-        "merge-stream": "2.0.0",
-        "supports-color": "7.1.0"
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -9329,7 +9329,7 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "4.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -9351,7 +9351,7 @@
       "integrity": "sha1-NiITz4YPRo8BJfxslqvBdCUx+Ug=",
       "dev": true,
       "requires": {
-        "easy-stack": "1.0.0"
+        "easy-stack": "^1.0.0"
       }
     },
     "js-tokens": {
@@ -9365,8 +9365,8 @@
       "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -9416,7 +9416,7 @@
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
       "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
       "requires": {
-        "string-convert": "0.2.1"
+        "string-convert": "^0.2.0"
       }
     },
     "json3": {
@@ -9431,7 +9431,7 @@
       "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.5"
+        "minimist": "^1.2.5"
       }
     },
     "jsonfile": {
@@ -9440,7 +9440,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsprim": {
@@ -9473,7 +9473,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "launch-editor": {
@@ -9482,8 +9482,8 @@
       "integrity": "sha512-On+V7K2uZK6wK7x691ycSUbLD/FyKKelArkbaAMSSJU8JmqmhwN2+mnJDNINuJWSrh2L0kDk+ZQtbC/gOWUwLw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "shell-quote": "1.7.2"
+        "chalk": "^2.3.0",
+        "shell-quote": "^1.6.1"
       }
     },
     "launch-editor-middleware": {
@@ -9492,7 +9492,7 @@
       "integrity": "sha512-s0UO2/gEGiCgei3/2UN3SMuUj1phjQN8lcpnvgLSz26fAzNWPQ6Nf/kF5IFClnfU2ehp6LrmKdMU/beveO+2jg==",
       "dev": true,
       "requires": {
-        "launch-editor": "2.2.1"
+        "launch-editor": "^2.2.1"
       }
     },
     "leven": {
@@ -9507,7 +9507,7 @@
       "integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
       "dev": true,
       "requires": {
-        "leven": "3.1.0"
+        "leven": "^3.1.0"
       }
     },
     "levn": {
@@ -9516,8 +9516,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lines-and-columns": {
@@ -9532,15 +9532,15 @@
       "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
       "dev": true,
       "requires": {
-        "@samverschueren/stream-to-observable": "0.3.0",
-        "is-observable": "1.1.0",
-        "is-promise": "2.2.2",
-        "is-stream": "1.1.0",
-        "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.5.0",
-        "listr-verbose-renderer": "0.5.0",
-        "p-map": "2.1.0",
-        "rxjs": "6.5.5"
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
       },
       "dependencies": {
         "p-map": {
@@ -9563,14 +9563,14 @@
       "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "elegant-spinner": "1.0.1",
-        "figures": "1.7.0",
-        "indent-string": "3.2.0",
-        "log-symbols": "1.0.2",
-        "log-update": "2.3.0",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9591,11 +9591,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "figures": {
@@ -9604,8 +9604,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "indent-string": {
@@ -9620,7 +9620,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         },
         "strip-ansi": {
@@ -9629,7 +9629,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -9646,10 +9646,10 @@
       "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "cli-cursor": "2.1.0",
-        "date-fns": "1.30.1",
-        "figures": "2.0.0"
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
       },
       "dependencies": {
         "figures": {
@@ -9658,7 +9658,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         }
       }
@@ -9669,11 +9669,11 @@
       "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "parse-json": "4.0.0",
-        "pify": "4.0.1",
-        "strip-bom": "3.0.0",
-        "type-fest": "0.3.1"
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^4.0.0",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0",
+        "type-fest": "^0.3.0"
       },
       "dependencies": {
         "parse-json": {
@@ -9682,8 +9682,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "type-fest": {
@@ -9700,8 +9700,8 @@
       "integrity": "sha512-ldcgZpjNJj71n+2Mf6yetz+c9bM4xpKtNds4LbqXzU/PTdeAX0g3ytnU1AJMEcTk2Lex4Smpe3Q/eCTsvUBxbA==",
       "dev": true,
       "requires": {
-        "find-cache-dir": "0.1.1",
-        "mkdirp": "0.5.5"
+        "find-cache-dir": "^0.1.1",
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
         "find-cache-dir": {
@@ -9710,9 +9710,9 @@
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.5",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -9721,8 +9721,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -9731,7 +9731,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -9740,7 +9740,7 @@
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         }
       }
@@ -9757,9 +9757,9 @@
       "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
       "dev": true,
       "requires": {
-        "big.js": "5.2.2",
-        "emojis-list": "3.0.0",
-        "json5": "1.0.1"
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
       },
       "dependencies": {
         "json5": {
@@ -9768,7 +9768,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.5"
+            "minimist": "^1.2.0"
           }
         }
       }
@@ -9779,8 +9779,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -9860,8 +9860,8 @@
       "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.2.0"
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -9870,7 +9870,7 @@
       "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "^3.0.0"
       }
     },
     "lodash.toarray": {
@@ -9902,7 +9902,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2"
+        "chalk": "^2.0.1"
       }
     },
     "log-update": {
@@ -9911,9 +9911,9 @@
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "cli-cursor": "2.1.0",
-        "wrap-ansi": "3.0.1"
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -9940,8 +9940,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -9950,7 +9950,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "wrap-ansi": {
@@ -9959,8 +9959,8 @@
           "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
           }
         }
       }
@@ -9982,7 +9982,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lowdb": {
@@ -9990,11 +9990,11 @@
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
       "integrity": "sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==",
       "requires": {
-        "graceful-fs": "4.2.4",
-        "is-promise": "2.2.2",
-        "lodash": "4.17.15",
-        "pify": "3.0.0",
-        "steno": "0.4.4"
+        "graceful-fs": "^4.1.3",
+        "is-promise": "^2.1.0",
+        "lodash": "4",
+        "pify": "^3.0.0",
+        "steno": "^0.4.1"
       },
       "dependencies": {
         "pify": {
@@ -10016,7 +10016,7 @@
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.2"
       }
     },
     "lowercase-keys": {
@@ -10031,7 +10031,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
-        "yallist": "3.1.1"
+        "yallist": "^3.0.2"
       }
     },
     "make-dir": {
@@ -10040,8 +10040,8 @@
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "requires": {
-        "pify": "4.0.1",
-        "semver": "5.7.1"
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
       }
     },
     "make-error": {
@@ -10062,7 +10062,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "md5.js": {
@@ -10071,9 +10071,9 @@
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
-        "hash-base": "3.1.0",
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "mdn-data": {
@@ -10094,8 +10094,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.7"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "merge-descriptors": {
@@ -10110,7 +10110,7 @@
       "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "dev": true,
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "^0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -10144,19 +10144,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.3",
-        "nanomatch": "1.2.13",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "miller-rabin": {
@@ -10165,8 +10165,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.9",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
@@ -10208,10 +10208,10 @@
       "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.4.0",
+        "loader-utils": "^1.1.0",
         "normalize-url": "1.9.1",
-        "schema-utils": "1.0.0",
-        "webpack-sources": "1.4.3"
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
       },
       "dependencies": {
         "normalize-url": {
@@ -10220,10 +10220,10 @@
           "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "prepend-http": "1.0.4",
-            "query-string": "4.3.4",
-            "sort-keys": "1.1.2"
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
           }
         },
         "schema-utils": {
@@ -10232,9 +10232,9 @@
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
-            "ajv": "6.12.2",
-            "ajv-errors": "1.0.1",
-            "ajv-keywords": "3.4.1"
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
           }
         }
       }
@@ -10257,7 +10257,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -10271,7 +10271,7 @@
       "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "dev": true,
       "requires": {
-        "yallist": "4.0.0"
+        "yallist": "^4.0.0"
       },
       "dependencies": {
         "yallist": {
@@ -10288,7 +10288,7 @@
       "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
       "dev": true,
       "requires": {
-        "minipass": "3.1.3"
+        "minipass": "^3.0.0"
       }
     },
     "minipass-flush": {
@@ -10297,7 +10297,7 @@
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
       "dev": true,
       "requires": {
-        "minipass": "3.1.3"
+        "minipass": "^3.0.0"
       }
     },
     "minipass-pipeline": {
@@ -10306,7 +10306,7 @@
       "integrity": "sha512-cFOknTvng5vqnwOpDsZTWhNll6Jf8o2x+/diplafmxpuIymAjzoOolZG0VvQf3V2HgqzJNhnuKHYp2BqDgz8IQ==",
       "dev": true,
       "requires": {
-        "minipass": "3.1.3"
+        "minipass": "^3.0.0"
       }
     },
     "mississippi": {
@@ -10315,16 +10315,16 @@
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "duplexify": "3.7.1",
-        "end-of-stream": "1.4.4",
-        "flush-write-stream": "1.1.1",
-        "from2": "2.3.0",
-        "parallel-transform": "1.2.0",
-        "pump": "3.0.0",
-        "pumpify": "1.5.1",
-        "stream-each": "1.2.3",
-        "through2": "2.0.5"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -10333,8 +10333,8 @@
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -10343,7 +10343,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -10353,7 +10353,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "1.2.5"
+        "minimist": "^1.2.5"
       }
     },
     "moment": {
@@ -10367,12 +10367,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.5",
-        "rimraf": "2.7.1",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -10386,8 +10386,8 @@
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "dev": true,
       "requires": {
-        "dns-packet": "1.3.1",
-        "thunky": "1.1.0"
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
       }
     },
     "multicast-dns-service-types": {
@@ -10413,9 +10413,9 @@
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "nan": {
@@ -10436,17 +10436,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.3",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "natural-compare": {
@@ -10485,7 +10485,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-emoji": {
@@ -10493,7 +10493,7 @@
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
       "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
       "requires": {
-        "lodash.toarray": "4.4.0"
+        "lodash.toarray": "^4.4.0"
       }
     },
     "node-fetch": {
@@ -10524,29 +10524,29 @@
       "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "dev": true,
       "requires": {
-        "assert": "1.5.0",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.2",
-        "console-browserify": "1.2.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "3.1.0",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.1",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.7",
-        "stream-browserify": "2.0.2",
-        "stream-http": "2.8.3",
-        "string_decoder": "1.1.1",
-        "timers-browserify": "2.0.11",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.11.1",
-        "vm-browserify": "1.1.2"
+        "url": "^0.11.0",
+        "util": "^0.11.0",
+        "vm-browserify": "^1.0.1"
       },
       "dependencies": {
         "punycode": {
@@ -10569,16 +10569,16 @@
       "integrity": "sha512-VGPaqQBNk193lrJFotBU8nvWZPqEZY2eIzymy2jjY0fJ9qIsxA0sxQ8ATPl0gZC645gijYEc1jtZvpS8QWzJGQ==",
       "dev": true,
       "requires": {
-        "chokidar": "2.1.8",
-        "debug": "3.2.6",
-        "ignore-by-default": "1.0.1",
-        "minimatch": "3.0.4",
-        "pstree.remy": "1.1.8",
-        "semver": "5.7.1",
-        "supports-color": "5.5.0",
-        "touch": "3.1.0",
-        "undefsafe": "2.0.3",
-        "update-notifier": "2.5.0"
+        "chokidar": "^2.1.8",
+        "debug": "^3.2.6",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.0.4",
+        "pstree.remy": "^1.1.7",
+        "semver": "^5.7.1",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.2",
+        "update-notifier": "^2.5.0"
       },
       "dependencies": {
         "anymatch": {
@@ -10587,8 +10587,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "3.1.10",
-            "normalize-path": "2.1.1"
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
           },
           "dependencies": {
             "normalize-path": {
@@ -10597,7 +10597,7 @@
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
               "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
               }
             }
           }
@@ -10614,18 +10614,18 @@
           "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
           "dev": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.3",
-            "braces": "2.3.2",
-            "fsevents": "1.2.13",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.4",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.1",
-            "normalize-path": "3.0.0",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.2.1",
-            "upath": "1.2.0"
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
           }
         },
         "debug": {
@@ -10634,7 +10634,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "fsevents": {
@@ -10644,8 +10644,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "1.5.0",
-            "nan": "2.14.1"
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "glob-parent": {
@@ -10654,8 +10654,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -10664,7 +10664,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -10675,7 +10675,7 @@
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "dev": true,
           "requires": {
-            "binary-extensions": "1.13.1"
+            "binary-extensions": "^1.0.0"
           }
         },
         "readdirp": {
@@ -10684,9 +10684,9 @@
           "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4",
-            "micromatch": "3.1.10",
-            "readable-stream": "2.3.7"
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
           }
         }
       }
@@ -10697,7 +10697,7 @@
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -10706,10 +10706,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.8.8",
-        "resolve": "1.17.0",
-        "semver": "5.7.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -10736,7 +10736,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "nth-check": {
@@ -10745,7 +10745,7 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -10777,9 +10777,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -10788,7 +10788,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -10797,7 +10797,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -10820,8 +10820,8 @@
       "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "object-keys": {
@@ -10848,7 +10848,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.assign": {
@@ -10857,10 +10857,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.1",
-        "object-keys": "1.1.1"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.getownpropertydescriptors": {
@@ -10869,8 +10869,8 @@
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.pick": {
@@ -10879,7 +10879,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "object.values": {
@@ -10888,10 +10888,10 @@
       "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "obuf": {
@@ -10905,7 +10905,7 @@
       "resolved": "https://registry.npmjs.org/omit.js/-/omit.js-1.0.2.tgz",
       "integrity": "sha512-/QPc6G2NS+8d4L/cQhbk6Yit1WTB6Us2g84A7A/1+w9d/eRGHyEqC5kkQtHVoHZ5NFWGG7tUGgrhVZwgZanKrQ==",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.23.0"
       }
     },
     "on-finished": {
@@ -10929,7 +10929,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -10938,7 +10938,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "open": {
@@ -10947,7 +10947,7 @@
       "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
       "dev": true,
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "opener": {
@@ -10962,7 +10962,7 @@
       "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
       "dev": true,
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "optimism": {
@@ -10970,7 +10970,7 @@
       "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
       "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
       "requires": {
-        "@wry/context": "0.4.4"
+        "@wry/context": "^0.4.0"
       }
     },
     "optionator": {
@@ -10979,12 +10979,12 @@
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "word-wrap": "1.2.3"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
       }
     },
     "ora": {
@@ -10993,12 +10993,12 @@
       "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "2.3.0",
-        "log-symbols": "2.2.0",
-        "strip-ansi": "5.2.0",
-        "wcwidth": "1.0.1"
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^2.0.0",
+        "log-symbols": "^2.2.0",
+        "strip-ansi": "^5.2.0",
+        "wcwidth": "^1.0.1"
       },
       "dependencies": {
         "strip-ansi": {
@@ -11007,7 +11007,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -11018,7 +11018,7 @@
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "dev": true,
       "requires": {
-        "url-parse": "1.4.7"
+        "url-parse": "^1.4.3"
       }
     },
     "os-browserify": {
@@ -11045,7 +11045,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -11054,7 +11054,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
@@ -11063,7 +11063,7 @@
       "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
       "dev": true,
       "requires": {
-        "aggregate-error": "3.0.1"
+        "aggregate-error": "^3.0.0"
       }
     },
     "p-retry": {
@@ -11072,7 +11072,7 @@
       "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
       "dev": true,
       "requires": {
-        "retry": "0.12.0"
+        "retry": "^0.12.0"
       }
     },
     "p-try": {
@@ -11087,10 +11087,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.4.0",
-        "registry-url": "3.1.0",
-        "semver": "5.7.1"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       }
     },
     "pako": {
@@ -11105,9 +11105,9 @@
       "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
       "dev": true,
       "requires": {
-        "cyclist": "1.0.1",
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.7"
+        "cyclist": "^1.0.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       }
     },
     "param-case": {
@@ -11116,7 +11116,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "parent-module": {
@@ -11125,7 +11125,7 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
-        "callsites": "3.1.0"
+        "callsites": "^3.0.0"
       },
       "dependencies": {
         "callsites": {
@@ -11142,12 +11142,12 @@
       "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.17",
-        "safe-buffer": "5.1.2"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
       }
     },
     "parse-json": {
@@ -11156,10 +11156,10 @@
       "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.10.1",
-        "error-ex": "1.3.2",
-        "json-parse-better-errors": "1.0.2",
-        "lines-and-columns": "1.1.6"
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1",
+        "lines-and-columns": "^1.1.6"
       }
     },
     "parse5": {
@@ -11174,7 +11174,7 @@
       "integrity": "sha512-CF+TKjXqoqyDwHqBhFQ+3l5t83xYi6fVT1tQNg+Ye0JRLnTxWvIroCjEp1A0k4lneHNBGnICUf0cfYVYGEazqw==",
       "dev": true,
       "requires": {
-        "parse5": "5.1.1"
+        "parse5": "^5.1.1"
       }
     },
     "parseurl": {
@@ -11189,8 +11189,8 @@
       "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.0",
-        "upper-case-first": "1.1.2"
+        "camel-case": "^3.0.0",
+        "upper-case-first": "^1.1.0"
       }
     },
     "pascalcase": {
@@ -11205,8 +11205,8 @@
       "integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "cross-spawn": "6.0.5"
+        "ansi-escapes": "^3.1.0",
+        "cross-spawn": "^6.0.5"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -11229,7 +11229,7 @@
       "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "path-dirname": {
@@ -11280,7 +11280,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -11297,11 +11297,11 @@
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
@@ -11333,7 +11333,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -11342,7 +11342,7 @@
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "dev": true,
       "requires": {
-        "find-up": "3.0.0"
+        "find-up": "^3.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -11351,7 +11351,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "locate-path": {
@@ -11360,8 +11360,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -11370,7 +11370,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -11379,7 +11379,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -11396,7 +11396,7 @@
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "pnp-webpack-plugin": {
@@ -11405,7 +11405,7 @@
       "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
       "dev": true,
       "requires": {
-        "ts-pnp": "1.2.0"
+        "ts-pnp": "^1.1.6"
       }
     },
     "popper.js": {
@@ -11424,9 +11424,9 @@
       "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
       "dev": true,
       "requires": {
-        "async": "2.6.3",
-        "debug": "3.2.6",
-        "mkdirp": "0.5.5"
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
         "debug": {
@@ -11435,7 +11435,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -11452,9 +11452,9 @@
       "integrity": "sha512-a937VDHE1ftkjk+8/7nj/mrjtmkn69xxzJgRETXdAUU+IgOYPQNJF17haGWbeDxSyk++HA14UA98FurvPyBJOA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "source-map": "0.6.1",
-        "supports-color": "6.1.0"
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -11469,7 +11469,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -11480,9 +11480,9 @@
       "integrity": "sha512-rofZFHUg6ZIrvRwPeFktv06GdbDYLcGqh9EwiMutZg+a0oePCCw1zHOEiji6LCpyRcjTREtPASuUqeAvYlEVvQ==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31",
-        "postcss-selector-parser": "6.0.2",
-        "postcss-value-parser": "4.1.0"
+        "postcss": "^7.0.27",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "postcss-colormin": {
@@ -11491,11 +11491,11 @@
       "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.12.0",
-        "color": "3.1.2",
-        "has": "1.0.3",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "browserslist": "^4.0.0",
+        "color": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11512,8 +11512,8 @@
       "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11530,7 +11530,7 @@
       "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-duplicates": {
@@ -11539,7 +11539,7 @@
       "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-empty": {
@@ -11548,7 +11548,7 @@
       "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-overridden": {
@@ -11557,7 +11557,7 @@
       "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-load-config": {
@@ -11566,8 +11566,8 @@
       "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "5.2.1",
-        "import-cwd": "2.1.0"
+        "cosmiconfig": "^5.0.0",
+        "import-cwd": "^2.0.0"
       }
     },
     "postcss-loader": {
@@ -11576,10 +11576,10 @@
       "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.4.0",
-        "postcss": "7.0.31",
-        "postcss-load-config": "2.1.0",
-        "schema-utils": "1.0.0"
+        "loader-utils": "^1.1.0",
+        "postcss": "^7.0.0",
+        "postcss-load-config": "^2.0.0",
+        "schema-utils": "^1.0.0"
       },
       "dependencies": {
         "schema-utils": {
@@ -11588,9 +11588,9 @@
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
-            "ajv": "6.12.2",
-            "ajv-errors": "1.0.1",
-            "ajv-keywords": "3.4.1"
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
           }
         }
       }
@@ -11602,9 +11602,9 @@
       "dev": true,
       "requires": {
         "css-color-names": "0.0.4",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1",
-        "stylehacks": "4.0.3"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "stylehacks": "^4.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11621,12 +11621,12 @@
       "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
       "dev": true,
       "requires": {
-        "browserslist": "4.12.0",
-        "caniuse-api": "3.0.0",
-        "cssnano-util-same-parent": "4.0.1",
-        "postcss": "7.0.31",
-        "postcss-selector-parser": "3.1.2",
-        "vendors": "1.0.4"
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "cssnano-util-same-parent": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0",
+        "vendors": "^1.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -11635,9 +11635,9 @@
           "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
           "dev": true,
           "requires": {
-            "dot-prop": "5.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^5.2.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -11648,8 +11648,8 @@
       "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11666,10 +11666,10 @@
       "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "is-color-stop": "1.1.0",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "is-color-stop": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11686,12 +11686,12 @@
       "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "browserslist": "4.12.0",
-        "cssnano-util-get-arguments": "4.0.0",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.0",
+        "browserslist": "^4.0.0",
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11708,10 +11708,10 @@
       "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.3",
-        "postcss": "7.0.31",
-        "postcss-selector-parser": "3.1.2"
+        "alphanum-sort": "^1.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -11720,9 +11720,9 @@
           "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
           "dev": true,
           "requires": {
-            "dot-prop": "5.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^5.2.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -11733,7 +11733,7 @@
       "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31"
+        "postcss": "^7.0.5"
       }
     },
     "postcss-modules-local-by-default": {
@@ -11742,10 +11742,10 @@
       "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
       "dev": true,
       "requires": {
-        "icss-utils": "4.1.1",
-        "postcss": "7.0.31",
-        "postcss-selector-parser": "6.0.2",
-        "postcss-value-parser": "4.1.0"
+        "icss-utils": "^4.1.1",
+        "postcss": "^7.0.16",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.0"
       }
     },
     "postcss-modules-scope": {
@@ -11754,8 +11754,8 @@
       "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31",
-        "postcss-selector-parser": "6.0.2"
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
       }
     },
     "postcss-modules-values": {
@@ -11764,8 +11764,8 @@
       "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
       "dev": true,
       "requires": {
-        "icss-utils": "4.1.1",
-        "postcss": "7.0.31"
+        "icss-utils": "^4.0.0",
+        "postcss": "^7.0.6"
       }
     },
     "postcss-normalize-charset": {
@@ -11774,7 +11774,7 @@
       "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-normalize-display-values": {
@@ -11783,9 +11783,9 @@
       "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11802,10 +11802,10 @@
       "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11822,10 +11822,10 @@
       "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11842,9 +11842,9 @@
       "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
       "dev": true,
       "requires": {
-        "has": "1.0.3",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11861,9 +11861,9 @@
       "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11880,9 +11880,9 @@
       "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "dev": true,
       "requires": {
-        "browserslist": "4.12.0",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11899,10 +11899,10 @@
       "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
       "dev": true,
       "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "3.3.0",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11919,8 +11919,8 @@
       "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11937,9 +11937,9 @@
       "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11956,10 +11956,10 @@
       "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
       "dev": true,
       "requires": {
-        "browserslist": "4.12.0",
-        "caniuse-api": "3.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.31"
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0"
       }
     },
     "postcss-reduce-transforms": {
@@ -11968,10 +11968,10 @@
       "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -11988,9 +11988,9 @@
       "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
       "dev": true,
       "requires": {
-        "cssesc": "3.0.0",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "postcss-svgo": {
@@ -11999,10 +11999,10 @@
       "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
       "dev": true,
       "requires": {
-        "is-svg": "3.0.0",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "3.3.1",
-        "svgo": "1.3.2"
+        "is-svg": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "svgo": "^1.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -12019,9 +12019,9 @@
       "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "7.0.31",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.0",
+        "postcss": "^7.0.0",
+        "uniqs": "^2.0.0"
       }
     },
     "postcss-value-parser": {
@@ -12054,7 +12054,7 @@
       "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "dev": true,
       "requires": {
-        "fast-diff": "1.2.0"
+        "fast-diff": "^1.1.2"
       }
     },
     "pretty-error": {
@@ -12063,8 +12063,8 @@
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "dev": true,
       "requires": {
-        "renderkid": "2.0.3",
-        "utila": "0.4.0"
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
       }
     },
     "private": {
@@ -12102,7 +12102,7 @@
       "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
     },
@@ -12136,12 +12136,12 @@
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.9",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.5",
-        "randombytes": "2.1.0",
-        "safe-buffer": "5.1.2"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       },
       "dependencies": {
         "bn.js": {
@@ -12158,8 +12158,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.4",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -12168,9 +12168,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "3.7.1",
-        "inherits": "2.0.4",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       },
       "dependencies": {
         "pump": {
@@ -12179,8 +12179,8 @@
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.4",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -12208,8 +12208,8 @@
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -12235,7 +12235,7 @@
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "requires": {
-        "performance-now": "2.1.0"
+        "performance-now": "^2.1.0"
       }
     },
     "randombytes": {
@@ -12244,7 +12244,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -12253,8 +12253,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.1.0",
-        "safe-buffer": "5.1.2"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -12281,10 +12281,10 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.5",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "strip-json-comments": {
@@ -12301,10 +12301,10 @@
       "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
       "dev": true,
       "requires": {
-        "@types/normalize-package-data": "2.4.0",
-        "normalize-package-data": "2.5.0",
-        "parse-json": "5.0.0",
-        "type-fest": "0.6.0"
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
       }
     },
     "readable-stream": {
@@ -12312,13 +12312,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.4",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.1",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -12328,7 +12328,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "picomatch": "2.2.2"
+        "picomatch": "^2.2.1"
       }
     },
     "recast": {
@@ -12338,9 +12338,9 @@
       "dev": true,
       "requires": {
         "ast-types": "0.13.3",
-        "esprima": "4.0.1",
-        "private": "0.1.8",
-        "source-map": "0.6.1"
+        "esprima": "~4.0.0",
+        "private": "^0.1.8",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -12357,7 +12357,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.17.0"
+        "resolve": "^1.1.6"
       }
     },
     "redeyed": {
@@ -12366,7 +12366,7 @@
       "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
       "dev": true,
       "requires": {
-        "esprima": "4.0.1"
+        "esprima": "~4.0.0"
       }
     },
     "regenerate": {
@@ -12381,7 +12381,7 @@
       "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0"
+        "regenerate": "^1.4.0"
       }
     },
     "regenerator-runtime": {
@@ -12396,8 +12396,8 @@
       "integrity": "sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.10.1",
-        "private": "0.1.8"
+        "@babel/runtime": "^7.8.4",
+        "private": "^0.1.8"
       }
     },
     "regex-not": {
@@ -12406,8 +12406,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexp.prototype.flags": {
@@ -12416,8 +12416,8 @@
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "regexpp": {
@@ -12432,12 +12432,12 @@
       "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0",
-        "regenerate-unicode-properties": "8.2.0",
-        "regjsgen": "0.5.2",
-        "regjsparser": "0.6.4",
-        "unicode-match-property-ecmascript": "1.0.4",
-        "unicode-match-property-value-ecmascript": "1.2.0"
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.2.0",
+        "regjsgen": "^0.5.1",
+        "regjsparser": "^0.6.4",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.2.0"
       }
     },
     "registry-auth-token": {
@@ -12446,8 +12446,8 @@
       "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "dev": true,
       "requires": {
-        "rc": "1.2.8",
-        "safe-buffer": "5.1.2"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -12456,7 +12456,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.8"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -12471,7 +12471,7 @@
       "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -12500,11 +12500,11 @@
       "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
       "dev": true,
       "requires": {
-        "css-select": "1.2.0",
-        "dom-converter": "0.2.0",
-        "htmlparser2": "3.10.1",
-        "strip-ansi": "3.0.1",
-        "utila": "0.4.0"
+        "css-select": "^1.1.0",
+        "dom-converter": "^0.2",
+        "htmlparser2": "^3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "^0.4.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12519,10 +12519,10 @@
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
           "dev": true,
           "requires": {
-            "boolbase": "1.0.0",
-            "css-what": "2.1.3",
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
             "domutils": "1.5.1",
-            "nth-check": "1.0.2"
+            "nth-check": "~1.0.1"
           }
         },
         "css-what": {
@@ -12537,8 +12537,8 @@
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "dev": true,
           "requires": {
-            "dom-serializer": "0.2.2",
-            "domelementtype": "1.3.1"
+            "dom-serializer": "0",
+            "domelementtype": "1"
           }
         },
         "strip-ansi": {
@@ -12547,7 +12547,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -12570,26 +12570,26 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.10.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.8",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.27",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.5.0",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.4.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "request-promise-core": {
@@ -12598,7 +12598,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "request-promise-native": {
@@ -12608,8 +12608,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.3",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.5.0"
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "require-directory": {
@@ -12641,7 +12641,7 @@
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
@@ -12650,7 +12650,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "resolve-from": {
@@ -12671,8 +12671,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.3"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -12705,7 +12705,7 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.6"
+        "glob": "^7.1.3"
       }
     },
     "ripemd160": {
@@ -12714,8 +12714,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.1.0",
-        "inherits": "2.0.4"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "run-async": {
@@ -12730,7 +12730,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0"
+        "aproba": "^1.1.1"
       }
     },
     "rxjs": {
@@ -12739,7 +12739,7 @@
       "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
       "dev": true,
       "requires": {
-        "tslib": "1.13.0"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -12753,7 +12753,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -12774,9 +12774,9 @@
       "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
       "dev": true,
       "requires": {
-        "@types/json-schema": "7.0.4",
-        "ajv": "6.12.2",
-        "ajv-keywords": "3.4.1"
+        "@types/json-schema": "^7.0.4",
+        "ajv": "^6.12.2",
+        "ajv-keywords": "^3.4.1"
       }
     },
     "select-hose": {
@@ -12806,7 +12806,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.7.1"
+        "semver": "^5.0.3"
       }
     },
     "send": {
@@ -12816,18 +12816,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.7.2",
+        "http-errors": "~1.7.2",
         "mime": "1.6.0",
         "ms": "2.1.1",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.1",
-        "statuses": "1.5.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -12867,8 +12867,8 @@
       "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case-first": "1.1.2"
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
       }
     },
     "serialize-javascript": {
@@ -12882,13 +12882,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.4",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.3",
-        "mime-types": "2.1.27",
-        "parseurl": "1.3.3"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -12906,10 +12906,10 @@
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": "1.5.0"
+            "statuses": ">= 1.4.0 < 2"
           }
         },
         "inherits": {
@@ -12938,9 +12938,9 @@
       "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.3",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
         "send": "0.17.1"
       }
     },
@@ -12956,10 +12956,10 @@
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -12968,7 +12968,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -12991,8 +12991,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shallow-equal": {
@@ -13011,7 +13011,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -13032,9 +13032,9 @@
       "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
       "dev": true,
       "requires": {
-        "glob": "7.1.6",
-        "interpret": "1.4.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "shortid": {
@@ -13042,7 +13042,7 @@
       "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
       "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
       "requires": {
-        "nanoid": "2.1.11"
+        "nanoid": "^2.1.0"
       }
     },
     "signal-exit": {
@@ -13057,7 +13057,7 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.3.2"
+        "is-arrayish": "^0.3.1"
       },
       "dependencies": {
         "is-arrayish": {
@@ -13080,9 +13080,9 @@
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "astral-regex": "1.0.0",
-        "is-fullwidth-code-point": "2.0.0"
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -13099,7 +13099,7 @@
       "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "snapdragon": {
@@ -13108,14 +13108,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.3",
-        "use": "3.1.1"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -13133,7 +13133,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -13142,7 +13142,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "ms": {
@@ -13159,9 +13159,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -13170,7 +13170,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -13179,7 +13179,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -13188,7 +13188,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -13197,9 +13197,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.3"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -13210,7 +13210,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -13219,7 +13219,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -13230,8 +13230,8 @@
       "integrity": "sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA==",
       "dev": true,
       "requires": {
-        "faye-websocket": "0.10.0",
-        "uuid": "3.4.0",
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.4.0",
         "websocket-driver": "0.6.5"
       }
     },
@@ -13241,12 +13241,12 @@
       "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
       "dev": true,
       "requires": {
-        "debug": "3.2.6",
-        "eventsource": "1.0.7",
-        "faye-websocket": "0.11.3",
-        "inherits": "2.0.4",
-        "json3": "3.3.3",
-        "url-parse": "1.4.7"
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
       },
       "dependencies": {
         "debug": {
@@ -13255,7 +13255,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "faye-websocket": {
@@ -13264,7 +13264,7 @@
           "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
           "dev": true,
           "requires": {
-            "websocket-driver": "0.6.5"
+            "websocket-driver": ">=0.5.1"
           }
         }
       }
@@ -13275,7 +13275,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-list-map": {
@@ -13296,11 +13296,11 @@
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
       "requires": {
-        "atob": "2.1.2",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -13309,8 +13309,8 @@
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -13333,8 +13333,8 @@
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.1",
-        "spdx-license-ids": "3.0.5"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -13349,8 +13349,8 @@
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.3.0",
-        "spdx-license-ids": "3.0.5"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -13365,11 +13365,11 @@
       "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
       "dev": true,
       "requires": {
-        "debug": "4.1.1",
-        "handle-thing": "2.0.1",
-        "http-deceiver": "1.2.7",
-        "select-hose": "2.0.0",
-        "spdy-transport": "3.0.0"
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
       }
     },
     "spdy-transport": {
@@ -13378,12 +13378,12 @@
       "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "dev": true,
       "requires": {
-        "debug": "4.1.1",
-        "detect-node": "2.0.4",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.2",
-        "readable-stream": "3.6.0",
-        "wbuf": "1.7.3"
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
       },
       "dependencies": {
         "readable-stream": {
@@ -13392,9 +13392,9 @@
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -13405,7 +13405,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -13420,15 +13420,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "ssri": {
@@ -13437,7 +13437,7 @@
       "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "requires": {
-        "figgy-pudding": "3.5.2"
+        "figgy-pudding": "^3.5.1"
       }
     },
     "stable": {
@@ -13458,8 +13458,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -13468,7 +13468,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -13490,7 +13490,7 @@
       "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
       "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
       "requires": {
-        "graceful-fs": "4.2.4"
+        "graceful-fs": "^4.1.3"
       }
     },
     "stream-browserify": {
@@ -13499,8 +13499,8 @@
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.7"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-each": {
@@ -13509,8 +13509,8 @@
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.4",
-        "stream-shift": "1.0.1"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-http": {
@@ -13519,11 +13519,11 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.7",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.2"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -13555,9 +13555,9 @@
       "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "requires": {
-        "emoji-regex": "8.0.0",
-        "is-fullwidth-code-point": "3.0.0",
-        "strip-ansi": "6.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "string.prototype.trimend": {
@@ -13566,8 +13566,8 @@
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string.prototype.trimleft": {
@@ -13576,9 +13576,9 @@
       "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "string.prototype.trimstart": "1.0.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
       }
     },
     "string.prototype.trimright": {
@@ -13587,9 +13587,9 @@
       "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "string.prototype.trimend": "1.0.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
       }
     },
     "string.prototype.trimstart": {
@@ -13598,8 +13598,8 @@
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {
@@ -13607,7 +13607,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -13616,7 +13616,7 @@
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "requires": {
-        "ansi-regex": "5.0.0"
+        "ansi-regex": "^5.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -13663,9 +13663,9 @@
       "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
       "dev": true,
       "requires": {
-        "browserslist": "4.12.0",
-        "postcss": "7.0.31",
-        "postcss-selector-parser": "3.1.2"
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -13674,9 +13674,9 @@
           "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
           "dev": true,
           "requires": {
-            "dot-prop": "5.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^5.2.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -13687,11 +13687,11 @@
       "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
       "dev": true,
       "requires": {
-        "backo2": "1.0.2",
-        "eventemitter3": "3.1.2",
-        "iterall": "1.3.0",
-        "symbol-observable": "1.2.0",
-        "ws": "5.2.2"
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0"
       },
       "dependencies": {
         "eventemitter3": {
@@ -13706,7 +13706,7 @@
           "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.1"
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -13716,16 +13716,16 @@
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
       "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "requires": {
-        "component-emitter": "1.3.0",
-        "cookiejar": "2.1.2",
-        "debug": "3.2.6",
-        "extend": "3.0.2",
-        "form-data": "2.3.3",
-        "formidable": "1.2.2",
-        "methods": "1.1.2",
-        "mime": "1.6.0",
-        "qs": "6.5.2",
-        "readable-stream": "2.3.7"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
       },
       "dependencies": {
         "debug": {
@@ -13733,7 +13733,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "mime": {
@@ -13748,7 +13748,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "supports-hyperlinks": {
@@ -13757,8 +13757,8 @@
       "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0",
-        "supports-color": "5.5.0"
+        "has-flag": "^2.0.0",
+        "supports-color": "^5.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -13781,19 +13781,19 @@
       "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "coa": "2.0.2",
-        "css-select": "2.1.0",
-        "css-select-base-adapter": "0.1.1",
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
         "css-tree": "1.0.0-alpha.37",
-        "csso": "4.0.3",
-        "js-yaml": "3.14.0",
-        "mkdirp": "0.5.5",
-        "object.values": "1.1.1",
-        "sax": "1.2.4",
-        "stable": "0.1.8",
-        "unquote": "1.1.1",
-        "util.promisify": "1.0.1"
+        "csso": "^4.0.2",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
       }
     },
     "swap-case": {
@@ -13802,8 +13802,8 @@
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4",
-        "upper-case": "1.1.3"
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
       }
     },
     "symbol-observable": {
@@ -13817,10 +13817,10 @@
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "ajv": "6.12.2",
-        "lodash": "4.17.15",
-        "slice-ansi": "2.1.0",
-        "string-width": "3.1.0"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "emoji-regex": {
@@ -13841,9 +13841,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -13852,7 +13852,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -13869,7 +13869,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "0.7.0"
+        "execa": "^0.7.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -13878,9 +13878,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.5",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "execa": {
@@ -13889,13 +13889,13 @@
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.3",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "get-stream": {
@@ -13910,8 +13910,8 @@
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "yallist": {
@@ -13928,9 +13928,9 @@
       "integrity": "sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==",
       "dev": true,
       "requires": {
-        "commander": "2.20.3",
-        "source-map": "0.6.1",
-        "source-map-support": "0.5.19"
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
       },
       "dependencies": {
         "source-map": {
@@ -13947,15 +13947,15 @@
       "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "dev": true,
       "requires": {
-        "cacache": "12.0.4",
-        "find-cache-dir": "2.1.0",
-        "is-wsl": "1.1.0",
-        "schema-utils": "1.0.0",
-        "serialize-javascript": "2.1.2",
-        "source-map": "0.6.1",
-        "terser": "4.7.0",
-        "webpack-sources": "1.4.3",
-        "worker-farm": "1.7.0"
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^2.1.2",
+        "source-map": "^0.6.1",
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
       },
       "dependencies": {
         "schema-utils": {
@@ -13964,9 +13964,9 @@
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
-            "ajv": "6.12.2",
-            "ajv-errors": "1.0.1",
-            "ajv-keywords": "3.4.1"
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
           }
         },
         "source-map": {
@@ -13989,7 +13989,7 @@
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0"
+        "any-promise": "^1.0.0"
       }
     },
     "thenify-all": {
@@ -13998,7 +13998,7 @@
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
-        "thenify": "3.3.0"
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "thread-loader": {
@@ -14007,9 +14007,9 @@
       "integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
       "dev": true,
       "requires": {
-        "loader-runner": "2.4.0",
-        "loader-utils": "1.4.0",
-        "neo-async": "2.6.1"
+        "loader-runner": "^2.3.1",
+        "loader-utils": "^1.1.0",
+        "neo-async": "^2.6.0"
       }
     },
     "throttle-debounce": {
@@ -14029,8 +14029,8 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.7",
-        "xtend": "4.0.2"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       }
     },
     "thunky": {
@@ -14051,7 +14051,7 @@
       "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "dev": true,
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "timsort": {
@@ -14071,8 +14071,8 @@
       "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
       }
     },
     "tmp": {
@@ -14081,7 +14081,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -14102,7 +14102,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -14111,7 +14111,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -14122,10 +14122,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -14134,8 +14134,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "toidentifier": {
@@ -14156,7 +14156,7 @@
       "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
       "dev": true,
       "requires": {
-        "nopt": "1.0.10"
+        "nopt": "~1.0.10"
       }
     },
     "tough-cookie": {
@@ -14165,8 +14165,8 @@
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "1.8.0",
-        "punycode": "2.1.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "treeify": {
@@ -14186,7 +14186,7 @@
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
       "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
       "requires": {
-        "tslib": "1.13.0"
+        "tslib": "^1.9.3"
       }
     },
     "ts-node": {
@@ -14195,10 +14195,10 @@
       "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
       "dev": true,
       "requires": {
-        "arg": "4.1.3",
-        "diff": "4.0.2",
-        "make-error": "1.3.6",
-        "source-map-support": "0.5.19",
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       }
     },
@@ -14231,7 +14231,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -14246,7 +14246,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-fest": {
@@ -14262,7 +14262,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.27"
+        "mime-types": "~2.1.24"
       }
     },
     "typedarray": {
@@ -14277,8 +14277,8 @@
       "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
       "dev": true,
       "requires": {
-        "commander": "2.19.0",
-        "source-map": "0.6.1"
+        "commander": "~2.19.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -14301,7 +14301,7 @@
       "integrity": "sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.2.0"
       },
       "dependencies": {
         "debug": {
@@ -14338,8 +14338,8 @@
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "1.0.4",
-        "unicode-property-aliases-ecmascript": "1.1.0"
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -14360,10 +14360,10 @@
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "2.0.1"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {
@@ -14384,7 +14384,7 @@
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
-        "unique-slug": "2.0.2"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -14393,7 +14393,7 @@
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "unique-string": {
@@ -14402,7 +14402,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "universalify": {
@@ -14429,8 +14429,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -14439,9 +14439,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -14481,16 +14481,16 @@
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.4.2",
-        "configstore": "3.1.2",
-        "import-lazy": "2.1.0",
-        "is-ci": "1.2.1",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "upper-case": {
@@ -14505,7 +14505,7 @@
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "dev": true,
       "requires": {
-        "upper-case": "1.1.3"
+        "upper-case": "^1.1.1"
       }
     },
     "uri-js": {
@@ -14514,7 +14514,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -14552,9 +14552,9 @@
       "integrity": "sha512-goSdg8VY+7nPZKUEChZSEtW5gjbS66USIGCeSJ1OVOJ7Yfuh/36YxCwMi5HVEJh6mqUYOoy3NJ0vlOMrWsSHog==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.4.0",
-        "mime": "2.4.6",
-        "schema-utils": "2.7.0"
+        "loader-utils": "^1.2.3",
+        "mime": "^2.4.4",
+        "schema-utils": "^2.5.0"
       }
     },
     "url-parse": {
@@ -14563,8 +14563,8 @@
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "dev": true,
       "requires": {
-        "querystringify": "2.1.1",
-        "requires-port": "1.0.0"
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {
@@ -14573,7 +14573,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "use": {
@@ -14610,10 +14610,10 @@
       "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "has-symbols": "1.0.1",
-        "object.getownpropertydescriptors": "2.1.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
       }
     },
     "utila": {
@@ -14646,8 +14646,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.1.1",
-        "spdx-expression-parse": "3.0.1"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {
@@ -14668,9 +14668,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -14692,7 +14692,7 @@
       "dev": true,
       "requires": {
         "vscode-languageserver-protocol": "3.14.1",
-        "vscode-uri": "1.0.6"
+        "vscode-uri": "^1.0.6"
       }
     },
     "vscode-languageserver-protocol": {
@@ -14701,7 +14701,7 @@
       "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
       "dev": true,
       "requires": {
-        "vscode-jsonrpc": "4.0.0",
+        "vscode-jsonrpc": "^4.0.0",
         "vscode-languageserver-types": "3.14.0"
       }
     },
@@ -14727,9 +14727,9 @@
       "resolved": "https://registry.npmjs.org/vue-apollo/-/vue-apollo-3.0.3.tgz",
       "integrity": "sha512-WJaQ1v/i46/oIPlKv7J0Tx6tTlbuaeCdhrAbL06h+Zca2gzr5ywjUFpl8ijMTGJsQ+Ph/U4xEpBFBOMxQmL+7g==",
       "requires": {
-        "chalk": "2.4.2",
-        "serialize-javascript": "2.1.2",
-        "throttle-debounce": "2.1.0"
+        "chalk": "^2.4.2",
+        "serialize-javascript": "^2.1.0",
+        "throttle-debounce": "^2.1.0"
       }
     },
     "vue-cli-plugin-apollo": {
@@ -14738,33 +14738,33 @@
       "integrity": "sha512-8CzRVrAsFkB9lpl600cRCNR9OUnrSYYAIVF9/qW4pP0TMXbhrd1F1wEAAN6E0CPimjTLB+qSt6zWS4vb2wC8Wg==",
       "dev": true,
       "requires": {
-        "apollo": "2.28.0",
-        "apollo-cache-inmemory": "1.6.6",
-        "apollo-client": "2.6.10",
-        "apollo-link": "1.2.14",
-        "apollo-link-context": "1.0.20",
-        "apollo-link-http": "1.5.17",
-        "apollo-link-persisted-queries": "0.2.2",
-        "apollo-link-state": "0.4.2",
-        "apollo-link-ws": "1.0.20",
-        "apollo-server-express": "2.14.2",
-        "apollo-upload-client": "11.0.0",
-        "apollo-utilities": "1.3.4",
-        "chalk": "2.4.2",
-        "deepmerge": "4.2.2",
-        "dotenv": "8.2.0",
-        "esm": "3.2.25",
-        "execa": "3.4.0",
-        "express": "4.17.1",
-        "fs-extra": "8.1.0",
-        "graphql": "14.6.0",
-        "graphql-subscriptions": "1.1.0",
-        "graphql-tag": "2.10.3",
-        "graphql-tools": "4.0.8",
-        "node-fetch": "2.6.0",
-        "nodemon": "1.19.4",
-        "subscriptions-transport-ws": "0.9.16",
-        "ts-node": "8.10.2"
+        "apollo": "^2.20.0",
+        "apollo-cache-inmemory": "^1.6.3",
+        "apollo-client": "^2.6.4",
+        "apollo-link": "^1.2.13",
+        "apollo-link-context": "^1.0.19",
+        "apollo-link-http": "^1.5.16",
+        "apollo-link-persisted-queries": "^0.2.2",
+        "apollo-link-state": "^0.4.2",
+        "apollo-link-ws": "^1.0.19",
+        "apollo-server-express": "^2.9.6",
+        "apollo-upload-client": "^11.0.0",
+        "apollo-utilities": "^1.3.2",
+        "chalk": "^2.4.2",
+        "deepmerge": "^4.1.1",
+        "dotenv": "^8.2.0",
+        "esm": "^3.2.25",
+        "execa": "^3.2.0",
+        "express": "^4.17.1",
+        "fs-extra": "^8.1.0",
+        "graphql": "^14.5.8",
+        "graphql-subscriptions": "^1.1.0",
+        "graphql-tag": "^2.10.1",
+        "graphql-tools": "^4.0.5",
+        "node-fetch": "^2.6.0",
+        "nodemon": "^1.19.4",
+        "subscriptions-transport-ws": "^0.9.16",
+        "ts-node": "^8.4.1"
       },
       "dependencies": {
         "cross-spawn": {
@@ -14773,9 +14773,9 @@
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.1",
-            "shebang-command": "2.0.0",
-            "which": "2.0.2"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "deepmerge": {
@@ -14790,16 +14790,16 @@
           "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
           "dev": true,
           "requires": {
-            "cross-spawn": "7.0.3",
-            "get-stream": "5.1.0",
-            "human-signals": "1.1.1",
-            "is-stream": "2.0.0",
-            "merge-stream": "2.0.0",
-            "npm-run-path": "4.0.1",
-            "onetime": "5.1.0",
-            "p-finally": "2.0.1",
-            "signal-exit": "3.0.3",
-            "strip-final-newline": "2.0.0"
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
         },
         "fs-extra": {
@@ -14808,9 +14808,9 @@
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "get-stream": {
@@ -14819,7 +14819,7 @@
           "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "graphql": {
@@ -14828,7 +14828,7 @@
           "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
           "dev": true,
           "requires": {
-            "iterall": "1.3.0"
+            "iterall": "^1.2.2"
           }
         },
         "is-stream": {
@@ -14849,7 +14849,7 @@
           "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
           "dev": true,
           "requires": {
-            "path-key": "3.1.1"
+            "path-key": "^3.0.0"
           }
         },
         "onetime": {
@@ -14858,7 +14858,7 @@
           "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
           "dev": true,
           "requires": {
-            "mimic-fn": "2.1.0"
+            "mimic-fn": "^2.1.0"
           }
         },
         "p-finally": {
@@ -14879,7 +14879,7 @@
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
-            "shebang-regex": "3.0.0"
+            "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
@@ -14894,7 +14894,7 @@
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -14905,12 +14905,12 @@
       "integrity": "sha512-Kr21uPfthDc63nDl27AGQEhtt9VrZ9nkYk/NTftJ2ws9XiJwzJJCnCr3AITQ2jpRMA0XPGDECxYH8E027qMK9Q==",
       "dev": true,
       "requires": {
-        "debug": "4.1.1",
-        "eslint-scope": "5.1.0",
-        "eslint-visitor-keys": "1.1.0",
-        "espree": "6.2.1",
-        "esquery": "1.3.1",
-        "lodash": "4.17.15"
+        "debug": "^4.1.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.2.1",
+        "esquery": "^1.0.1",
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "eslint-scope": {
@@ -14919,8 +14919,8 @@
           "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
           "dev": true,
           "requires": {
-            "esrecurse": "4.2.1",
-            "estraverse": "4.3.0"
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         }
       }
@@ -14941,7 +14941,7 @@
       "resolved": "https://registry.npmjs.org/vue-js-modal/-/vue-js-modal-2.0.0-rc.3.tgz",
       "integrity": "sha512-Q9L9FsIUMuzCKSuB41D8LxV+Yc2q+zWHzzUdWaQ2KeHPS+78+X6AAnBztVoophbjt8UXHO7rQSRgER1MMw5qsw==",
       "requires": {
-        "resize-observer-polyfill": "1.5.1"
+        "resize-observer-polyfill": "^1.5.1"
       }
     },
     "vue-loader": {
@@ -14950,11 +14950,11 @@
       "integrity": "sha512-oXBubaY//CYEISBlHX+c2YPJbmOH68xXPXjFv4MAgPqQvUsnjrBAjCJi8HXZ/r/yfn0tPL5VZj1Zcp8mJPI8VA==",
       "dev": true,
       "requires": {
-        "@vue/component-compiler-utils": "3.1.2",
-        "hash-sum": "1.0.2",
-        "loader-utils": "1.4.0",
-        "vue-hot-reload-api": "2.3.4",
-        "vue-style-loader": "4.1.2"
+        "@vue/component-compiler-utils": "^3.1.0",
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.1.0",
+        "vue-hot-reload-api": "^2.3.0",
+        "vue-style-loader": "^4.1.0"
       },
       "dependencies": {
         "hash-sum": {
@@ -14980,8 +14980,8 @@
       "resolved": "https://registry.npmjs.org/vue-sidebar-menu/-/vue-sidebar-menu-4.5.4.tgz",
       "integrity": "sha512-KSH56kwG+R0uPi4hCj3YYp0AMcIAlVQqdOPNYzeN+3bmGF2/2s/T5ks/KpmBPbgvTf0z2LVwcweKrVeGIPq25A==",
       "requires": {
-        "path-to-regexp": "1.8.0",
-        "vue": "2.6.11"
+        "path-to-regexp": "^1.7.0",
+        "vue": "^2.5.21"
       },
       "dependencies": {
         "isarray": {
@@ -15005,8 +15005,8 @@
       "integrity": "sha512-0ip8ge6Gzz/Bk0iHovU9XAUQaFt/G2B61bnWa2tCcqqdgfHs1lF9xXorFbE55Gmy92okFT+8bfmySuUOu13vxQ==",
       "dev": true,
       "requires": {
-        "hash-sum": "1.0.2",
-        "loader-utils": "1.4.0"
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.0.2"
       },
       "dependencies": {
         "hash-sum": {
@@ -15023,8 +15023,8 @@
       "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
       "dev": true,
       "requires": {
-        "de-indent": "1.0.2",
-        "he": "1.2.0"
+        "de-indent": "^1.0.2",
+        "he": "^1.1.0"
       }
     },
     "vue-template-es2015-compiler": {
@@ -15043,7 +15043,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {
@@ -15052,10 +15052,10 @@
       "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
       "dev": true,
       "requires": {
-        "chokidar": "3.4.0",
-        "graceful-fs": "4.2.4",
-        "neo-async": "2.6.1",
-        "watchpack-chokidar2": "2.0.0"
+        "chokidar": "^3.4.0",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
       }
     },
     "watchpack-chokidar2": {
@@ -15065,7 +15065,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "chokidar": "2.1.8"
+        "chokidar": "^2.1.8"
       },
       "dependencies": {
         "anymatch": {
@@ -15075,8 +15075,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "micromatch": "3.1.10",
-            "normalize-path": "2.1.1"
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
           },
           "dependencies": {
             "normalize-path": {
@@ -15086,7 +15086,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
               }
             }
           }
@@ -15105,18 +15105,18 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.3",
-            "braces": "2.3.2",
-            "fsevents": "1.2.13",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.4",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.1",
-            "normalize-path": "3.0.0",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.2.1",
-            "upath": "1.2.0"
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
           }
         },
         "fsevents": {
@@ -15126,8 +15126,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "1.5.0",
-            "nan": "2.14.1"
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "glob-parent": {
@@ -15137,8 +15137,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -15148,7 +15148,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -15160,7 +15160,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "binary-extensions": "1.13.1"
+            "binary-extensions": "^1.0.0"
           }
         },
         "readdirp": {
@@ -15170,9 +15170,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "graceful-fs": "4.2.4",
-            "micromatch": "3.1.10",
-            "readable-stream": "2.3.7"
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
           }
         }
       }
@@ -15183,7 +15183,7 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
-        "minimalistic-assert": "1.0.1"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "wcwidth": {
@@ -15192,7 +15192,7 @@
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
-        "defaults": "1.0.3"
+        "defaults": "^1.0.3"
       }
     },
     "webpack": {
@@ -15205,25 +15205,25 @@
         "@webassemblyjs/helper-module-context": "1.9.0",
         "@webassemblyjs/wasm-edit": "1.9.0",
         "@webassemblyjs/wasm-parser": "1.9.0",
-        "acorn": "6.4.1",
-        "ajv": "6.12.2",
-        "ajv-keywords": "3.4.1",
-        "chrome-trace-event": "1.0.2",
-        "enhanced-resolve": "4.1.1",
-        "eslint-scope": "4.0.3",
-        "json-parse-better-errors": "1.0.2",
-        "loader-runner": "2.4.0",
-        "loader-utils": "1.4.0",
-        "memory-fs": "0.4.1",
-        "micromatch": "3.1.10",
-        "mkdirp": "0.5.5",
-        "neo-async": "2.6.1",
-        "node-libs-browser": "2.2.1",
-        "schema-utils": "1.0.0",
-        "tapable": "1.1.3",
-        "terser-webpack-plugin": "1.4.3",
-        "watchpack": "1.7.2",
-        "webpack-sources": "1.4.3"
+        "acorn": "^6.4.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^4.1.0",
+        "eslint-scope": "^4.0.3",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.3",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.6.1",
+        "webpack-sources": "^1.4.1"
       },
       "dependencies": {
         "schema-utils": {
@@ -15232,9 +15232,9 @@
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
-            "ajv": "6.12.2",
-            "ajv-errors": "1.0.1",
-            "ajv-keywords": "3.4.1"
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
           }
         }
       }
@@ -15245,19 +15245,19 @@
       "integrity": "sha512-PODQhAYVEourCcOuU+NiYI7WdR8QyELZGgPvB1y2tjbUpbmcQOt5Q7jEK+ttd5se0KSBKD9SXHCEozS++Wllmw==",
       "dev": true,
       "requires": {
-        "acorn": "7.2.0",
-        "acorn-walk": "7.1.1",
-        "bfj": "6.1.2",
-        "chalk": "2.4.2",
-        "commander": "2.20.3",
-        "ejs": "2.7.4",
-        "express": "4.17.1",
-        "filesize": "3.6.1",
-        "gzip-size": "5.1.1",
-        "lodash": "4.17.15",
-        "mkdirp": "0.5.5",
-        "opener": "1.5.1",
-        "ws": "6.2.1"
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1",
+        "bfj": "^6.1.1",
+        "chalk": "^2.4.1",
+        "commander": "^2.18.0",
+        "ejs": "^2.6.1",
+        "express": "^4.16.3",
+        "filesize": "^3.6.1",
+        "gzip-size": "^5.0.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^0.5.1",
+        "opener": "^1.5.1",
+        "ws": "^6.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -15274,8 +15274,8 @@
       "integrity": "sha512-f97PYqxU+9/u0IUqp/ekAHRhBD1IQwhBv3wlJo2nvyELpr2vNnUqO3XQEk+qneg0uWGP54iciotszpjfnEExFA==",
       "dev": true,
       "requires": {
-        "deepmerge": "1.5.2",
-        "javascript-stringify": "2.0.1"
+        "deepmerge": "^1.5.2",
+        "javascript-stringify": "^2.0.1"
       }
     },
     "webpack-dev-middleware": {
@@ -15284,11 +15284,11 @@
       "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
       "dev": true,
       "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "2.4.6",
-        "mkdirp": "0.5.5",
-        "range-parser": "1.2.1",
-        "webpack-log": "2.0.0"
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
       }
     },
     "webpack-dev-server": {
@@ -15298,38 +15298,38 @@
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
-        "bonjour": "3.5.0",
-        "chokidar": "2.1.8",
-        "compression": "1.7.4",
-        "connect-history-api-fallback": "1.6.0",
-        "debug": "4.1.1",
-        "del": "4.1.1",
-        "express": "4.17.1",
-        "html-entities": "1.3.1",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.3.1",
         "http-proxy-middleware": "0.19.1",
-        "import-local": "2.0.0",
-        "internal-ip": "4.3.0",
-        "ip": "1.1.5",
-        "is-absolute-url": "3.0.3",
-        "killable": "1.0.1",
-        "loglevel": "1.6.8",
-        "opn": "5.5.0",
-        "p-retry": "3.0.1",
-        "portfinder": "1.0.26",
-        "schema-utils": "1.0.0",
-        "selfsigned": "1.10.7",
-        "semver": "6.3.0",
-        "serve-index": "1.9.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.8",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.26",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
         "sockjs": "0.3.20",
         "sockjs-client": "1.4.0",
-        "spdy": "4.0.2",
-        "strip-ansi": "3.0.1",
-        "supports-color": "6.1.0",
-        "url": "0.11.0",
-        "webpack-dev-middleware": "3.7.2",
-        "webpack-log": "2.0.0",
-        "ws": "6.2.1",
-        "yargs": "13.3.2"
+        "spdy": "^4.0.2",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "^13.3.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -15344,8 +15344,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "3.1.10",
-            "normalize-path": "2.1.1"
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
           },
           "dependencies": {
             "normalize-path": {
@@ -15354,7 +15354,7 @@
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
               "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
               }
             }
           }
@@ -15371,18 +15371,18 @@
           "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
           "dev": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.3",
-            "braces": "2.3.2",
-            "fsevents": "1.2.13",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.4",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.1",
-            "normalize-path": "3.0.0",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.2.1",
-            "upath": "1.2.0"
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
           }
         },
         "cliui": {
@@ -15391,9 +15391,9 @@
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0",
-            "wrap-ansi": "5.1.0"
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -15408,7 +15408,7 @@
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "dev": true,
               "requires": {
-                "ansi-regex": "4.1.0"
+                "ansi-regex": "^4.1.0"
               }
             }
           }
@@ -15425,7 +15425,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "fsevents": {
@@ -15435,8 +15435,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "1.5.0",
-            "nan": "2.14.1"
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "glob-parent": {
@@ -15445,8 +15445,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -15455,7 +15455,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -15472,7 +15472,7 @@
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "dev": true,
           "requires": {
-            "binary-extensions": "1.13.1"
+            "binary-extensions": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -15487,8 +15487,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -15497,7 +15497,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -15506,7 +15506,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -15521,9 +15521,9 @@
           "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4",
-            "micromatch": "3.1.10",
-            "readable-stream": "2.3.7"
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
           }
         },
         "schema-utils": {
@@ -15532,9 +15532,9 @@
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
-            "ajv": "6.12.2",
-            "ajv-errors": "1.0.1",
-            "ajv-keywords": "3.4.1"
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
           }
         },
         "semver": {
@@ -15549,9 +15549,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -15566,7 +15566,7 @@
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "dev": true,
               "requires": {
-                "ansi-regex": "4.1.0"
+                "ansi-regex": "^4.1.0"
               }
             }
           }
@@ -15577,7 +15577,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -15586,7 +15586,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "wrap-ansi": {
@@ -15595,9 +15595,9 @@
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -15612,7 +15612,7 @@
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "dev": true,
               "requires": {
-                "ansi-regex": "4.1.0"
+                "ansi-regex": "^4.1.0"
               }
             }
           }
@@ -15623,16 +15623,16 @@
           "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "dev": true,
           "requires": {
-            "cliui": "5.0.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "2.0.5",
-            "require-directory": "2.1.1",
-            "require-main-filename": "2.0.0",
-            "set-blocking": "2.0.0",
-            "string-width": "3.1.0",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "13.1.2"
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
           }
         },
         "yargs-parser": {
@@ -15641,8 +15641,8 @@
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -15653,8 +15653,8 @@
       "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
       "dev": true,
       "requires": {
-        "ansi-colors": "3.2.4",
-        "uuid": "3.4.0"
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
       }
     },
     "webpack-merge": {
@@ -15663,7 +15663,7 @@
       "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "webpack-sources": {
@@ -15672,8 +15672,8 @@
       "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
       "dev": true,
       "requires": {
-        "source-list-map": "2.0.1",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -15690,7 +15690,7 @@
       "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
       "dev": true,
       "requires": {
-        "websocket-extensions": "0.1.3"
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -15711,7 +15711,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -15726,7 +15726,7 @@
       "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -15747,8 +15747,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -15757,7 +15757,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -15779,7 +15779,7 @@
       "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "dev": true,
       "requires": {
-        "errno": "0.1.7"
+        "errno": "~0.1.7"
       }
     },
     "wrap-ansi": {
@@ -15788,9 +15788,9 @@
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "requires": {
-        "ansi-styles": "4.2.1",
-        "string-width": "4.2.0",
-        "strip-ansi": "6.0.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15799,8 +15799,8 @@
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "@types/color-name": "1.1.1",
-            "color-convert": "2.0.1"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "color-convert": {
@@ -15809,7 +15809,7 @@
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.4"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
@@ -15832,7 +15832,7 @@
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.5"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -15841,9 +15841,9 @@
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.3"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {
@@ -15852,7 +15852,7 @@
       "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.1"
+        "async-limiter": "~1.0.0"
       }
     },
     "xdg-basedir": {
@@ -15885,17 +15885,17 @@
       "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
       "dev": true,
       "requires": {
-        "cliui": "6.0.0",
-        "decamelize": "1.2.0",
-        "find-up": "4.1.0",
-        "get-caller-file": "2.0.5",
-        "require-directory": "2.1.1",
-        "require-main-filename": "2.0.0",
-        "set-blocking": "2.0.0",
-        "string-width": "4.2.0",
-        "which-module": "2.0.0",
-        "y18n": "4.0.0",
-        "yargs-parser": "18.1.3"
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.1"
       },
       "dependencies": {
         "find-up": {
@@ -15904,8 +15904,8 @@
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "locate-path": "5.0.0",
-            "path-exists": "4.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "locate-path": {
@@ -15914,7 +15914,7 @@
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
-            "p-locate": "4.1.0"
+            "p-locate": "^4.1.0"
           }
         },
         "p-limit": {
@@ -15923,7 +15923,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -15932,7 +15932,7 @@
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.2.0"
           }
         },
         "p-try": {
@@ -15955,8 +15955,8 @@
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
-        "camelcase": "5.3.1",
-        "decamelize": "1.2.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     },
     "yarn": {
@@ -15977,10 +15977,10 @@
       "integrity": "sha512-jcKpkthap6x63MB4TxwCyuIGkV0oYP/YRyuQU5UO0Yz/E/ZAu+653/uov+phdmO54n6BcvFRyyt0RRrWdN2mpw==",
       "dev": true,
       "requires": {
-        "execa": "0.8.0",
-        "is-ci": "1.2.1",
-        "normalize-path": "1.0.0",
-        "strip-indent": "2.0.0"
+        "execa": "^0.8.0",
+        "is-ci": "^1.0.10",
+        "normalize-path": "^1.0.0",
+        "strip-indent": "^2.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -15989,9 +15989,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.5",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "execa": {
@@ -16000,13 +16000,13 @@
           "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.3",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "get-stream": {
@@ -16021,8 +16021,8 @@
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "normalize-path": {
@@ -16049,8 +16049,8 @@
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
       "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
       "requires": {
-        "tslib": "1.13.0",
-        "zen-observable": "0.8.15"
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "parserOptions": {
       "parser": "babel-eslint"
     }
-
   },
   "browserslist": [
     "> 1%",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,34 +1,26 @@
 <template>
-<div>
-  <!-- <sidebartwo /> -->
+  <div>
+    <!-- <sidebartwo /> -->
 
- <Login />
- </div> 
+    <router-view />
+  </div>
 </template>
 
 <script>
 //import sidebar from './components/sidebar'
 //import sidebartwo from "./components/sidebartwo";
-import Login from './components/login'
-
 export default {
   name: "App",
   components: {
-    //  sidebar
-    Login
-
-    //sidebartwo
   },
-    async created() {
+  async created() {
     try {
-      console.log('123');
       await this.$auth.renewTokens();
     } catch {
       // Supress the 'not logged in' error as we can illegitimately get that
       // when processing the callback url
     }
   }
-
 };
 </script>
 

--- a/src/auth/authService.js
+++ b/src/auth/authService.js
@@ -20,7 +20,6 @@ class AuthService extends EventEmitter {
   tokenExpiry = null;
 
   login(customState) {
-    console.log('1234');
     webAuth.authorize();
   }
 
@@ -39,7 +38,6 @@ class AuthService extends EventEmitter {
   }
 
   handleAuthentication() {
-    console.log('hello');
     return new Promise((resolve, reject) => {
       webAuth.parseHash((err, authResult) => {
         if (err) {
@@ -83,7 +81,6 @@ class AuthService extends EventEmitter {
   }
 
   localLogin(authResult) {
-    console.log(authResult);
     this.idToken = authResult.idToken;
     this.profile = authResult.idTokenPayload;
 
@@ -102,20 +99,12 @@ class AuthService extends EventEmitter {
   }
 
   renewTokens() {
-   
     return new Promise((resolve, reject) => {
-      console.log(localStorage.getItem(localStorageKey));
-      console.log('1');
       if (localStorage.getItem(localStorageKey) !== "true") {
         return reject("Not logged in");
-        console.log('hi');
       }
-      console.log('123');
       webAuth.checkSession({}, (err, authResult) => {
-        console.log('12');
         if (err) {
-          console.log('inside');
-          console.log(err);
           localStorage.setItem(localStorageKey, "false");
           localStorage.removeItem("apollo-token");
           reject(err);

--- a/src/components/Callback.vue
+++ b/src/components/Callback.vue
@@ -1,8 +1,8 @@
   
 <template>
   <div class="spinner">
- <!--   <img src="../assets/loading.svg" alt="Loading"> -->
- <p>Loading... </p>
+    <!--   <img src="../assets/loading.svg" alt="Loading"> -->
+    <p>Loading...</p>
   </div>
 </template>
 
@@ -10,12 +10,11 @@
 export default {
   methods: {
     handleLoginEvent(data) {
-      // this.$router.push(data.state.target || "/");
-      window.location.href = data.state.target || "/";
+      this.$router.push(data.state.target || "/");
+      // window.location.href = data.state.target || "/";
     }
   },
   created() {
-    console.log('12345');
     this.$auth.handleAuthentication();
   }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -11,11 +11,13 @@ import { BootstrapVue, BootstrapVueIcons } from "bootstrap-vue";
 import { ApolloClient } from "apollo-client";
 import { HttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
+import AuthPlugin from "./plugins/auth";
 
 import "bootstrap/dist/css/bootstrap.css";
 import "bootstrap-vue/dist/bootstrap-vue.css";
 import VueApollo from "vue-apollo";
 
+Vue.use(AuthPlugin);
 Vue.use(BootstrapVue);
 Vue.use(BootstrapVueIcons);
 Vue.config.productionTip = false;

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,6 @@ import { InMemoryCache } from "apollo-cache-inmemory";
 import "bootstrap/dist/css/bootstrap.css";
 import "bootstrap-vue/dist/bootstrap-vue.css";
 import VueApollo from "vue-apollo";
-import { createProvider } from './vue-apollo'
 
 Vue.use(BootstrapVue);
 Vue.use(BootstrapVueIcons);
@@ -45,6 +44,5 @@ new Vue({
   router,
   apolloProvider,
   render: h => h(App),
-  apolloProvider: createProvider(),
   store
 }).$mount("#app");

--- a/src/router.js
+++ b/src/router.js
@@ -14,6 +14,8 @@ import Callback from "./components/Callback.vue";
 Vue.use(Router);
 
 const router = new Router({
+  mode: "history",
+  // See https://router.vuejs.org/guide/essentials/history-mode.html#html5-history-mode. 
   routes: [
     {
       path: "/",
@@ -55,21 +57,18 @@ const router = new Router({
       path: "/callback",
       name: "callback",
       component: Callback
-    }
+    },
+    // See https://router.vuejs.org/guide/essentials/history-mode.html#html5-history-mode. 
+    // { path: '*', component: NotFound }
   ]
 });
 
 router.beforeEach((to, from, next) => {
-  console.log('x');
-
-  if (to.path === "/login" || to.path === "/callback"  || auth.isAuthenticated()){
-    console.log('y');
-    return next();
+  if (to.path == "/callback" || auth.isAuthenticated()) {
+    next();
+  } else {
+    auth.login({ target: to.path });
   }
-  console.log( auth.isAuthenticated()); 
-  console.log('z');
-
-  auth.login({ target: to.path });
 });
 
 export default router;


### PR DESCRIPTION
Two main issues that have been fixed:
1) router mode changed to `history` in `router.js` as per tutorial source code (we missed it). Allows router to read the redirected path properly, previously our nav guard was seeing the entire auth token param as the path as opposed to `/callback`. Read inline commented link for more info.  
2) we did not include `Vue.use(authPlugin)` in `main.js` so the instance property `this$auth` was not registered on the prototype, and the `loginEvent` listener mixins were not registered. 

Note I also committed the `package-lock.json` my build generated, as it is recommended practice (locks the version of all packages to ensure compatibility). So take this out of ur gitignore if you have included it. Doesn't matter if you accept my copy this time, as long as you always push your latest package.lock file generated.